### PR TITLE
Various tweaks for Q2 rota generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We hope one day to make the rota generator think in terms of days rather than we
 
 ## Usage
 
-Once you've generated a `/data/combined.csv` file as per [Creating the input data](#creating-the-input-data), you can generate a rota by running `ruby /bin/generate_rota.rb` (it will output to STDOUT).
+Once you've generated a `/data/combined.csv` file as per [Creating the input data](#creating-the-input-data), you can generate a rota by running `ruby bin/generate_rota.rb` (it will output to STDOUT).
 
 Tweak the weighting in that file to place more or less emphasis on different cover types (e.g. oncall_primary).
 
@@ -27,17 +27,16 @@ This was very much hacked together for a prototype, and needs rebuilding properl
 
 1. Download the [Technical Support Google Sheet](https://docs.google.com/spreadsheets/d/1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU/edit#gid=1249170615) as a CSV, storing in `data/people.csv`.
    This CSV describes what roles developers are eligible for, e.g. whether or not they can do on-call.
-2. Download [Rota Availability Google Forms Responses](https://docs.google.com/forms/d/11Az5Y6acNYiqJPiIigHJRF-KdT8Fnpp2jmoQNysKzmg/edit#responses) as CSV, store as `data/responses.csv`.
-   This CSV describes which weeks developers are unavailable.
-3. Edit the `responses.csv` file so that it looks something like below.
-   It may be easier to export to Google Sheets first, and then rename the first row columns to "Week 1 (03/04/23 - 09/04/23)", and so on. Then re-export the CSV from Google Sheets.
+   Remember to delete the second row from the CSV, as this only contains hint text.
+2. Export the [Rota Availability Google Forms Responses](https://docs.google.com/forms/d/11Az5Y6acNYiqJPiIigHJRF-KdT8Fnpp2jmoQNysKzmg/edit#responses) to Google Sheets (use the "View in Sheets" option). Rename row F onwards to something that identifies each week (e.g. "Week 1 (03/04/23 - 09/04/23)"). Now export the sheet as a CSV, storing it as `data/responses.csv`. This CSV describes which weeks developers are unavailable.
+3. Check your `responses.csv` file should look something like below (also ensure that any newlines have been removed from the output):
 
 ```csv
 Timestamp,What is your name,What team will you be on? (team),"If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours",Do you have any non working days? [Non working day(s)],Week 1 (03/04/23 - 09/04/23),Week 2 (10/04/23 - 16/04/23),Week 3 (17/04/23 - 23/04/23),Week 4 (24/04/23 - 30/04/23),Week 5 (01/05/23 - 07/05/23),Week 6 (08/05/23 - 14/05/23),Week 7 (15/05/23 - 21/05/23),Week 8 (22/05/23 - 28/05/23),Week 9 (29/05/23 - 04/06/23),Week 10 (05/06/23 - 11/06/23),Week 11 (12/06/23 - 18/06/23),Week 12 (19/06/23 - 25/06/23),Week 13 (26/06/23 - 02/07/23),Need to elaborate on any of the above?
 10/02/2023 16:54:04,Some Person,Find and View,,,,,,,,"Not available for in-hours, Not available for on-call weekday nights, Not available for on-call over the weekend",,,,"Not available for in-hours, Not available for on-call weekday nights, Not available for on-call over the weekend",,,,
 ```
 
-4. Update the `week_headers` variable in `bin/combine_csvs.rb`, so that it knows which columns to read.
+4. Update the `week_headers` variable in `bin/combine_csvs.rb` to refer to the headings you wrote in step 2, so that it knows which columns to read.
 
 5. Run `ruby bin/combine_csvs.rb`. This will generate a `data/combined.csv` file.
 

--- a/spec/generate_rota_spec.rb
+++ b/spec/generate_rota_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe GenerateRota do
     ]
     slots_to_fill = described_class.new.slots_to_fill(1, roles_config)
 
-    expect { described_class.new.fill_slots(people, slots_to_fill) }.to raise_exception(CannotFillSlotException)
+    expect { described_class.new.fill_slots(people, slots_to_fill) }
+      .to output("WARNING: nobody is available for some_role in week 1\n").to_stdout
   end
 
   it "avoids allocating forbidden_weeks" do


### PR DESCRIPTION
- Clarify README instructions
- Avoid script failure if there's a lack of availability - better to continue with a few blanks.
- Handle on-call opt-outs better. Previously, someone who has opted out or is otherwise ineligible for on-call, and who checks the form boxes saying "not available for on-call" would not even be allocated to in-hours roles, as every week was considered a 'forbidden week'.

Trello: https://trello.com/c/VoQbOdIn/172-rota-q2-2023-24