### PR TITLE
Automate fetching and combining of both datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 data/
 
 .byebug_history
+
+google_service_account_key.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ data/
 .byebug_history
 
 google_service_account_key.json
+
+spec/tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ group :test do
   gem "byebug"
   gem "rspec"
   gem "rubocop-govuk", require: false
+  gem "webmock"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
+gem "google-apis-sheets_v4"
+gem "googleauth"
+
 group :test do
   gem "byebug"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,15 +11,21 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
     byebug (11.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     diff-lcs (1.5.1)
     drb (2.2.0)
       ruby2_keywords
+    hashdiff (1.1.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
@@ -30,6 +36,7 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    public_suffix (5.0.4)
     racc (1.7.3)
     rack (3.0.8)
     rainbow (3.1.1)
@@ -87,6 +94,10 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    webmock (3.22.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -95,6 +106,7 @@ DEPENDENCIES
   byebug
   rspec
   rubocop-govuk
+  webmock
 
 BUNDLED WITH
    2.4.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,16 +22,48 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    declarative (0.0.20)
     diff-lcs (1.5.1)
     drb (2.2.0)
       ruby2_keywords
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
+    google-apis-core (0.13.0)
+      addressable (~> 2.5, >= 2.5.1)
+      googleauth (~> 1.9)
+      httpclient (>= 2.8.1, < 3.a)
+      mini_mime (~> 1.0)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.a)
+      rexml
+    google-apis-sheets_v4 (0.27.0)
+      google-apis-core (>= 0.12.0, < 2.a)
+    google-cloud-env (2.1.1)
+      faraday (>= 1.0, < 3.a)
+    googleauth (1.11.0)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     hashdiff (1.1.0)
+    httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
+    jwt (2.8.0)
+      base64
     language_server-protocol (3.17.0.3)
+    mini_mime (1.1.5)
     minitest (5.21.2)
+    multi_json (1.15.0)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
+    os (1.1.4)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -41,6 +73,11 @@ GEM
     rack (3.0.8)
     rainbow (3.1.1)
     regexp_parser (2.9.0)
+    representable (3.2.0)
+      declarative (< 0.1.0)
+      trailblazer-option (>= 0.1.1, < 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.1.2)
     rexml (3.2.6)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -91,9 +128,17 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    signet (0.19.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+    trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uber (0.1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     webmock (3.22.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -104,6 +149,8 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  google-apis-sheets_v4
+  googleauth
   rspec
   rubocop-govuk
   webmock

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ We hope one day to make the rota generator think in terms of days rather than we
 
 ## Setup
 
-In GCP, there's a [govuk-rota-generator 'project'](https://console.cloud.google.com/?project=govuk-rota-generator) which has a [google-sheet-fetcher 'service account'](https://console.cloud.google.com/iam-admin/serviceaccounts/details/111167577478691063624;edit=true/keys?orgonly=true&project=govuk-rota-generator&supportedpurview=organizationId) (which automatically has its own email address `google-sheet-fetcher@govuk-rota-generator.iam.gserviceaccount.com`). From this screen, you can:
+In GCP, there's a [govuk-rota-generator 'project'](https://console.cloud.google.com/?project=govuk-rota-generator) which has a google-sheet-fetcher 'service account' (which automatically has its own email address `google-sheet-fetcher@govuk-rota-generator.iam.gserviceaccount.com`).
 
-> Add Key -> JSON -> Create
+The 2nd-line-support Google group is an 'Owner' of the service account, so anyone in that group should be able to create a service account key for local use. From the [google-sheet-fetcher service account page](https://console.cloud.google.com/iam-admin/serviceaccounts/details/111167577478691063624;edit=true/keys?orgonly=true&project=govuk-rota-generator&supportedpurview=organizationId):
 
-This will download a JSON file. Store it as `google_service_account_key.json` (which is git-ignored) in this repo.
+1. "Add Key" -> "JSON" -> "Create"
+2. This will download a JSON file.
+3. Store it as `google_service_account_key.json` (which is git-ignored) at the root of this repo.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,32 +13,29 @@ There are some limitations to the generator, which we hope to resolve in future 
 
 We hope one day to make the rota generator think in terms of days rather than weeks, and also have tighter integration with the `pay-pagerduty` repo (e.g. merging together under a new name).
 
+## Setup
+
+In GCP, there's a [govuk-rota-generator 'project'](https://console.cloud.google.com/?project=govuk-rota-generator) which has a [google-sheet-fetcher 'service account'](https://console.cloud.google.com/iam-admin/serviceaccounts/details/111167577478691063624;edit=true/keys?orgonly=true&project=govuk-rota-generator&supportedpurview=organizationId) (which automatically has its own email address `google-sheet-fetcher@govuk-rota-generator.iam.gserviceaccount.com`). From this screen, you can:
+
+> Add Key -> JSON -> Create
+
+This will download a JSON file. Store it as `google_service_account_key.json` (which is git-ignored) in this repo.
+
 ## Usage
 
-Once you've generated a `/data/combined.csv` file as per [Creating the input data](#creating-the-input-data), you can generate a rota by running `ruby bin/generate_rota.rb` (it will output to STDOUT).
+### Create a developer availability form
 
-Tweak the weighting in that file to place more or less emphasis on different cover types (e.g. oncall_primary).
+1. Clone the [form template](https://docs.google.com/forms/d/1PvCMjzCZeELjflHY22p6FH5rtPp3Lvql7LmHGoUSFjM/edit)
+2. Update the dates etc, but otherwise make no changes to the form structure
+3. Send out the form, gather responses
+4. Link it to a spreadsheet
+5. Share the spreadsheet with `google-sheet-fetcher@govuk-rota-generator.iam.gserviceaccount.com` (dismiss the warning about sharing with external email addresses)
 
-The generated output can be used as the `data/rota.csv` in [pay-pagerduty](https://github.com/alphagov/pay-pagerduty), which automates the overriding of PagerDuty schedules.
+### Get the data ready
 
-## Creating the input data
+1. Update the `AVAILABILITY_SHEET_ID` specified inside `combine_csvs.rb`, to refer to your responses spreadsheet.
 
-This was very much hacked together for a prototype, and needs rebuilding properly at some point.
-
-1. Download the [Technical Support Google Sheet](https://docs.google.com/spreadsheets/d/1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU/edit#gid=1249170615) as a CSV, storing in `data/people.csv`.
-   This CSV describes what roles developers are eligible for, e.g. whether or not they can do on-call.
-   Remember to delete the second row from the CSV, as this only contains hint text.
-2. Export the [Rota Availability Google Forms Responses](https://docs.google.com/forms/d/11Az5Y6acNYiqJPiIigHJRF-KdT8Fnpp2jmoQNysKzmg/edit#responses) to Google Sheets (use the "View in Sheets" option). Rename row F onwards to something that identifies each week (e.g. "Week 1 (03/04/23 - 09/04/23)"). Now export the sheet as a CSV, storing it as `data/responses.csv`. This CSV describes which weeks developers are unavailable.
-3. Check your `responses.csv` file should look something like below (also ensure that any newlines have been removed from the output):
-
-```csv
-Timestamp,What is your name,What team will you be on? (team),"If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours",Do you have any non working days? [Non working day(s)],Week 1 (03/04/23 - 09/04/23),Week 2 (10/04/23 - 16/04/23),Week 3 (17/04/23 - 23/04/23),Week 4 (24/04/23 - 30/04/23),Week 5 (01/05/23 - 07/05/23),Week 6 (08/05/23 - 14/05/23),Week 7 (15/05/23 - 21/05/23),Week 8 (22/05/23 - 28/05/23),Week 9 (29/05/23 - 04/06/23),Week 10 (05/06/23 - 11/06/23),Week 11 (12/06/23 - 18/06/23),Week 12 (19/06/23 - 25/06/23),Week 13 (26/06/23 - 02/07/23),Need to elaborate on any of the above?
-10/02/2023 16:54:04,Some Person,Find and View,,,,,,,,"Not available for in-hours, Not available for on-call weekday nights, Not available for on-call over the weekend",,,,"Not available for in-hours, Not available for on-call weekday nights, Not available for on-call over the weekend",,,,
-```
-
-4. Update the `week_headers` variable in `bin/combine_csvs.rb` to refer to the headings you wrote in step 2, so that it knows which columns to read.
-
-5. Run `ruby bin/combine_csvs.rb`. This will generate a `data/combined.csv` file.
+2. Run `ruby bin/combine_csvs.rb`. This will generate a `data/combined.csv` file, combining your responses spreadsheet with the [Technical Support Google Sheet](https://docs.google.com/spreadsheets/d/1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU/edit#gid=1249170615).
 
 The generated file will look something like:
 
@@ -46,3 +43,11 @@ The generated file will look something like:
 name,team,can_do_inhours_primary,can_do_inhours_secondary,can_do_inhours_primary_standby,can_do_inhours_secondary_standby,can_do_oncall_primary,can_do_oncall_secondary,forbidden_weeks
 Some Person,Find and View,false,false,false,false,false,true,true,"6,10"
 ```
+
+### Generate the rota
+
+Run `ruby bin/generate_rota.rb` (it will output to STDOUT).
+
+Tweak the weighting in that file to place more or less emphasis on different cover types (e.g. oncall_primary).
+
+The generated output can be used as the `data/rota.csv` in [pay-pagerduty](https://github.com/alphagov/pay-pagerduty), which automates the overriding of PagerDuty schedules.

--- a/bin/generate_rota.rb
+++ b/bin/generate_rota.rb
@@ -48,5 +48,5 @@ generator.people.sort_by { |person| fairness_calculator.weight_of_shifts(person.
     shift_count = person.assigned_shifts.select { |shift| shift[:role] == role }.count
     "#{shift_count} #{role}"
   end
-  puts "#{person.name} has been allocated #{sprintf('%.1f', fairness_calculator.weight_of_shifts(person.assigned_shifts))} units of inconvenience (#{person.assigned_shifts.count} shifts made up of #{shift_totals.join(',')})"
+  puts "#{person.email} has been allocated #{sprintf('%.1f', fairness_calculator.weight_of_shifts(person.assigned_shifts))} units of inconvenience (#{person.assigned_shifts.count} shifts made up of #{shift_totals.join(',')})"
 end

--- a/lib/csv_validator.rb
+++ b/lib/csv_validator.rb
@@ -46,6 +46,7 @@ class CsvValidator
       unless date_next_week == expected_next_date
         raise InvalidStructureException, "Expected 'Week commencing #{date_next_week}' to be 'Week commencing #{expected_next_date}'"
       end
+
       date_this_week = date_next_week
     end
   end

--- a/lib/csv_validator.rb
+++ b/lib/csv_validator.rb
@@ -26,6 +26,19 @@ class CsvValidator
       end
     end
 
+    validate_week_dates(week_columns.map { |hash| hash[:value].sub("Week commencing ", "") })
+
     true
+  end
+
+  def self.validate_week_dates(week_dates)
+    date_this_week = week_dates.shift(1).first
+    week_dates.each do |date_next_week|
+      expected_next_date = (Date.parse(date_this_week) + 7).strftime("%d/%m/%Y")
+      unless date_next_week == expected_next_date
+        raise InvalidStructureException, "Expected 'Week commencing #{date_next_week}' to be 'Week commencing #{expected_next_date}'"
+      end
+      date_this_week = date_next_week
+    end
   end
 end

--- a/lib/csv_validator.rb
+++ b/lib/csv_validator.rb
@@ -1,3 +1,5 @@
+require "date"
+
 class InvalidStructureException < StandardError; end
 
 class CsvValidator
@@ -33,6 +35,12 @@ class CsvValidator
 
   def self.validate_week_dates(week_dates)
     date_this_week = week_dates.shift(1).first
+    day_of_week = Date.parse(date_this_week).strftime("%A")
+
+    unless day_of_week == "Monday"
+      raise InvalidStructureException, "Expected column 'Week commencing #{date_this_week}' to correspond to a Monday, but it's a #{day_of_week}."
+    end
+
     week_dates.each do |date_next_week|
       expected_next_date = (Date.parse(date_this_week) + 7).strftime("%d/%m/%Y")
       unless date_next_week == expected_next_date

--- a/lib/csv_validator.rb
+++ b/lib/csv_validator.rb
@@ -1,0 +1,31 @@
+class InvalidStructureException < StandardError; end
+
+class CsvValidator
+  def self.validate_columns(csv)
+    first_columns_regexes = [
+      /^Timestamp$/,
+      /^Email address$/,
+      /^Have you been given an exemption from on call\?/,
+      /^Do you have any non working days\?/,
+      /^What team\/area are you in/,
+      /^If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours/,
+    ]
+    week_commencing_regex = /^Week commencing \d+{2}\/\d{2}\/\d{4}$/
+    last_column_regex = /^Need to elaborate on any of the above\?/
+
+    columns = csv.first
+    first_columns = columns.shift(first_columns_regexes.count).each_with_index.map do |column, index|
+      { regex: first_columns_regexes[index], value: column }
+    end
+    last_column = [columns.pop].map { |column| { regex: last_column_regex, value: column } }
+    week_columns = columns.map { |column| { regex: week_commencing_regex, value: column } }
+
+    (first_columns + week_columns + last_column).each do |hash|
+      unless hash[:value].match(hash[:regex])
+        raise InvalidStructureException, "Expected '#{hash[:value]}' to match '#{hash[:regex]}'"
+      end
+    end
+
+    true
+  end
+end

--- a/lib/generate_rota.rb
+++ b/lib/generate_rota.rb
@@ -60,7 +60,7 @@ class GenerateRota
 
   def slots_filled(people)
     shifts = people.reduce([]) do |arr, person|
-      arr + person.assigned_shifts.map { |shift| shift.merge(assignee: person.name) }
+      arr + person.assigned_shifts.map { |shift| shift.merge(assignee: person.email) }
     end
     shifts.sort_by { |shift| shift[:week] }
   end
@@ -105,7 +105,7 @@ private
         person_hash[:can_do_oncall_secondary] == "true" ? :oncall_secondary : nil,
       ].compact
       Person.new(
-        name: person_hash[:name],
+        email: person_hash[:email],
         team: person_hash[:team],
         forbidden_weeks:,
         can_do_roles:,

--- a/lib/google_sheet.rb
+++ b/lib/google_sheet.rb
@@ -1,0 +1,22 @@
+require "googleauth"
+require "google/apis/sheets_v4"
+
+class MissingSheetException < StandardError; end
+class InvalidSheetStructureException < StandardError; end
+
+class GoogleSheet
+  def initialize(sheets_api: Google::Apis::SheetsV4::SheetsService.new)
+    authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open("./google_service_account_key.json"),
+      # https://developers.google.com/identity/protocols/oauth2/scopes#script
+      scope: Google::Apis::SheetsV4::AUTH_SPREADSHEETS_READONLY,
+    )
+    authorizer.fetch_access_token!
+    sheets_api.authorization = authorizer
+    @sheets_api = sheets_api
+  end
+
+  def fetch(sheet_id:, range:)
+    @sheets_api.get_spreadsheet_values(sheet_id, range)
+  end
+end

--- a/lib/google_sheet.rb
+++ b/lib/google_sheet.rb
@@ -16,7 +16,7 @@ class GoogleSheet
     @sheets_api = sheets_api
   end
 
-  def fetch(sheet_id:, range:)
+  def fetch(sheet_id:, range: "Form responses 1!A1:Z")
     @sheets_api.get_spreadsheet_values(sheet_id, range)
   end
 end

--- a/lib/google_sheet.rb
+++ b/lib/google_sheet.rb
@@ -16,7 +16,13 @@ class GoogleSheet
     @sheets_api = sheets_api
   end
 
-  def fetch(sheet_id:, range: "Form responses 1!A1:Z")
-    @sheets_api.get_spreadsheet_values(sheet_id, range)
+  def fetch(sheet_id:, range: "Form responses 1!A1:Z", filepath: nil)
+    data = @sheets_api.get_spreadsheet_values(sheet_id, range).values
+
+    if filepath
+      File.write(filepath, data.map(&:to_csv).join)
+    end
+
+    data
   end
 end

--- a/lib/person.rb
+++ b/lib/person.rb
@@ -6,10 +6,10 @@ class MultipleRolesException < StandardError; end
 class ShiftNotAssignedException < StandardError; end
 
 class Person
-  attr_reader :name, :team, :assigned_shifts, :random_factor
+  attr_reader :email, :team, :assigned_shifts, :random_factor
 
-  def initialize(name:, team:, can_do_roles:, forbidden_weeks:)
-    @name = name
+  def initialize(email:, team:, can_do_roles:, forbidden_weeks:)
+    @email = email
     @team = team
     @can_do_roles = can_do_roles
     @forbidden_weeks = forbidden_weeks
@@ -29,7 +29,7 @@ class Person
     raise ForbiddenRoleException unless can_do_role?(role)
     raise ForbiddenWeekException if availability(week:).empty?
     if (conflicting_shift = @assigned_shifts.find { |shift| shift[:week] == week })
-      raise MultipleRolesException, "Failed to assign role #{role} to #{name} in week #{week} as they're already assigned to #{conflicting_shift[:role]}"
+      raise MultipleRolesException, "Failed to assign role #{role} to #{email} in week #{week} as they're already assigned to #{conflicting_shift[:role]}"
     end
 
     @assigned_shifts << { week:, role: }

--- a/spec/csv_validator_spec.rb
+++ b/spec/csv_validator_spec.rb
@@ -57,5 +57,17 @@ RSpec.describe CsvValidator do
         "Expected 'Week commencing 01/04/2024' to match '(?-mix:^Need to elaborate on any of the above\\?)'",
       )
     end
+
+    it "raises an exception if the dates given aren't exactly 7 days apart" do
+      headers_with_inconsistent_dates = valid_headers.insert(valid_headers.count - 1, [
+        "Week commencing 08/04/2024",
+        "Week commencing 16/04/2024", # should be 15th
+      ]).flatten
+
+      expect { described_class.validate_columns([headers_with_inconsistent_dates]) }.to raise_exception(
+        InvalidStructureException,
+        "Expected 'Week commencing 16/04/2024' to be 'Week commencing 15/04/2024'",
+      )
+    end
   end
 end

--- a/spec/csv_validator_spec.rb
+++ b/spec/csv_validator_spec.rb
@@ -69,5 +69,15 @@ RSpec.describe CsvValidator do
         "Expected 'Week commencing 16/04/2024' to be 'Week commencing 15/04/2024'",
       )
     end
+
+    it "raises an exception if the first date isn't a Monday" do
+      bad_headers = valid_headers
+      bad_headers[valid_headers.count - 2] = "Week commencing 02/04/2024"
+
+      expect { described_class.validate_columns([bad_headers]) }.to raise_exception(
+        InvalidStructureException,
+        "Expected column 'Week commencing 02/04/2024' to correspond to a Monday, but it's a Tuesday.",
+      )
+    end
   end
 end

--- a/spec/csv_validator_spec.rb
+++ b/spec/csv_validator_spec.rb
@@ -1,0 +1,61 @@
+require "csv_validator"
+
+RSpec.describe CsvValidator do
+  describe ".validate_columns" do
+    let(:valid_headers) do
+      [
+        "Timestamp",
+        "Email address",
+        "Have you been given an exemption from on call?\n\nPlease select \"Yes\" only if you've opted out (with Senior Tech approval). Don't worry about checking the box if you're ineligible for on-call (e.g. Frontend Developer, or lack of prod access) - you'll be automatically opted out.",
+        "Do you have any non working days? [Non working day(s)]",
+        "What team/area are you in (or will be in when this rota starts)?",
+        "If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours",
+        "Week commencing 01/04/2024",
+        "Need to elaborate on any of the above?",
+      ]
+    end
+
+    it "raises an exception if columns are not in expected structure" do
+      bad_headers = [
+        "Timestampp", # deliberate typo
+      ]
+
+      expect { described_class.validate_columns([bad_headers]) }.to raise_exception(
+        InvalidStructureException,
+        "Expected 'Timestampp' to match '(?-mix:^Timestamp$)'",
+      )
+    end
+
+    it "returns true if columns are in expected structure" do
+      expect(described_class.validate_columns([valid_headers])).to eq(true)
+    end
+
+    it "supports multiple 'Week commencing' columns" do
+      valid_headers_multiple_weeks = valid_headers.insert(valid_headers.count - 1, [
+        "Week commencing 08/04/2024",
+        "Week commencing 15/04/2024",
+        "Week commencing 22/04/2024",
+        "Week commencing 29/04/2024",
+        "Week commencing 06/05/2024",
+        "Week commencing 13/05/2024",
+        "Week commencing 20/05/2024",
+        "Week commencing 27/05/2024",
+        "Week commencing 03/06/2024",
+        "Week commencing 10/06/2024",
+        "Week commencing 17/06/2024",
+        "Week commencing 24/06/2024",
+      ]).flatten
+
+      expect(described_class.validate_columns([valid_headers_multiple_weeks])).to eq(true)
+    end
+
+    it "raises an exception if the last column is missing" do
+      bad_headers = valid_headers[0...-1]
+
+      expect { described_class.validate_columns([bad_headers]) }.to raise_exception(
+        InvalidStructureException,
+        "Expected 'Week commencing 01/04/2024' to match '(?-mix:^Need to elaborate on any of the above\\?)'",
+      )
+    end
+  end
+end

--- a/spec/fixtures/availability.csv
+++ b/spec/fixtures/availability.csv
@@ -1,4 +1,4 @@
-name,team,can_do_inhours_primary,can_do_inhours_secondary,can_do_inhours_primary_standby,can_do_inhours_secondary_standby,can_do_oncall_primary,can_do_oncall_secondary,forbidden_weeks
+email,team,can_do_inhours_primary,can_do_inhours_secondary,can_do_inhours_primary_standby,can_do_inhours_secondary_standby,can_do_oncall_primary,can_do_oncall_secondary,forbidden_weeks
 Aiden Smith,Navigation and presentation,true,true,true,true,true,true,"2,4,5,6,9,10,11,12,13"
 Beatriz Gomez,Publishing team,true,true,true,true,true,true,"1,2,3,4,5,6,7,8,9"
 Chen Li,Publishing Platform,true,true,true,true,false,false,"3,4,8,13"

--- a/spec/generate_rota_spec.rb
+++ b/spec/generate_rota_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GenerateRota do
 
   it "raises an exception if a slot can't be filled" do
     people = [
-      Person.new(name: "Dev Eloper", team: "Foo", can_do_roles: [:some_role], forbidden_weeks: [1]),
+      Person.new(email: "Dev Eloper", team: "Foo", can_do_roles: [:some_role], forbidden_weeks: [1]),
     ]
     slots_to_fill = described_class.new.slots_to_fill(1, roles_config)
 
@@ -21,8 +21,8 @@ RSpec.describe GenerateRota do
 
   it "avoids allocating forbidden_weeks" do
     people = [
-      Person.new(name: "Busy Person",       team: "Foo", can_do_roles: [:some_role], forbidden_weeks: [1, 3]),
-      Person.new(name: "2nd Line Champion", team: "Bar", can_do_roles: [:some_role], forbidden_weeks: []),
+      Person.new(email: "Busy Person",       team: "Foo", can_do_roles: [:some_role], forbidden_weeks: [1, 3]),
+      Person.new(email: "2nd Line Champion", team: "Bar", can_do_roles: [:some_role], forbidden_weeks: []),
     ]
     slots_to_fill = described_class.new.slots_to_fill(3, roles_config)
 
@@ -34,9 +34,9 @@ RSpec.describe GenerateRota do
   end
 
   it "spreads shift assignment evenly" do
-    developer_a = Person.new(name: "Developer A", team: "Foo", can_do_roles: [:some_role], forbidden_weeks: [])
-    developer_b = Person.new(name: "Developer B", team: "Bar", can_do_roles: [:some_role], forbidden_weeks: [])
-    developer_c = Person.new(name: "Developer C", team: "Baz", can_do_roles: [:some_role], forbidden_weeks: [])
+    developer_a = Person.new(email: "Developer A", team: "Foo", can_do_roles: [:some_role], forbidden_weeks: [])
+    developer_b = Person.new(email: "Developer B", team: "Bar", can_do_roles: [:some_role], forbidden_weeks: [])
+    developer_c = Person.new(email: "Developer C", team: "Baz", can_do_roles: [:some_role], forbidden_weeks: [])
     people = [developer_a, developer_b, developer_c]
     slots_to_fill = described_class.new.slots_to_fill(9, roles_config)
 
@@ -48,8 +48,8 @@ RSpec.describe GenerateRota do
   end
 
   it "doesn't assign the same person to simultaneous shifts nor to shifts they can't do" do
-    developer_a = Person.new(name: "Developer A", team: "Foo", can_do_roles: %i[some_role some_other_role], forbidden_weeks: [])
-    developer_b = Person.new(name: "Developer B", team: "Bar", can_do_roles: [:some_role], forbidden_weeks: [])
+    developer_a = Person.new(email: "Developer A", team: "Foo", can_do_roles: %i[some_role some_other_role], forbidden_weeks: [])
+    developer_b = Person.new(email: "Developer B", team: "Bar", can_do_roles: [:some_role], forbidden_weeks: [])
     people = [developer_a, developer_b]
     roles_config = {
       some_role: {},

--- a/spec/google_sheet_spec.rb
+++ b/spec/google_sheet_spec.rb
@@ -1,0 +1,24 @@
+require "google_sheet"
+
+RSpec.describe GoogleSheet do
+  before do
+    mock_authorizer = instance_double("Google Authorizer", fetch_access_token!: true)
+    allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(mock_authorizer)
+  end
+
+  describe "#fetch" do
+    it "returns data if sheet is found" do
+      sheet_id = "1sK8ktAnffewnfiewnfoewifnwoein"
+      range = "Form responses 1!A1:Z"
+      mock_response = %w[foo]
+      mock_sheets_api = instance_double("Google::Apis::SheetsV4::SheetsService")
+      allow(mock_sheets_api).to receive(:authorization=)
+      allow(mock_sheets_api).to receive(:get_spreadsheet_values).with(sheet_id, range).and_return(mock_response)
+
+      result = described_class.new(sheets_api: mock_sheets_api)
+        .fetch(sheet_id:, range:)
+
+      expect(result).to be(mock_response)
+    end
+  end
+end

--- a/spec/google_sheet_spec.rb
+++ b/spec/google_sheet_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe GoogleSheet do
   before do
     mock_authorizer = instance_double("Google Authorizer", fetch_access_token!: true)
     allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(mock_authorizer)
+    allow(File).to receive(:open).with("./google_service_account_key.json").and_return("{}")
   end
 
   describe "#fetch" do

--- a/spec/google_sheet_spec.rb
+++ b/spec/google_sheet_spec.rb
@@ -17,19 +17,41 @@ RSpec.describe GoogleSheet do
 
     it "returns data if sheet is found" do
       range = "SomeWorksheet!A1:Z"
-      mock_response = %w[foo]
+      mock_response = instance_double("Google::Apis::SheetsV4::ValueRange", values: %w[foo])
       allow(mock_sheets_api).to receive(:get_spreadsheet_values).with(sheet_id, range).and_return(mock_response)
 
       result = described_class.new(sheets_api: mock_sheets_api)
         .fetch(sheet_id:, range:)
 
-      expect(result).to be(mock_response)
+      expect(result).to be(mock_response.values)
     end
 
     it "defaults to range 'Form responses 1!A1:Z' (the default worksheet name in spreadsheets linked to Forms)" do
+      allow(mock_sheets_api).to receive(:get_spreadsheet_values).and_return(
+        instance_double("Google::Apis::SheetsV4::ValueRange", values: %w[foo]),
+      )
       expect(mock_sheets_api).to receive(:get_spreadsheet_values).with(sheet_id, "Form responses 1!A1:Z")
 
       described_class.new(sheets_api: mock_sheets_api).fetch(sheet_id:)
+    end
+
+    it "saves the data as a CSV if filepath provided" do
+      mock_value_range = instance_double("Google::Apis::SheetsV4::ValueRange", values:
+        [
+          %w[foo bar],
+          %w[baz bash],
+        ])
+      allow(mock_sheets_api).to receive(:get_spreadsheet_values).and_return(mock_value_range)
+
+      filepath = "#{File.dirname(__FILE__)}/tmp/local.csv"
+      File.delete(filepath) if File.exist? filepath
+      described_class.new(sheets_api: mock_sheets_api).fetch(sheet_id: "some sheet id", range: "some range", filepath:)
+      expect(File.read(filepath)).to eq(
+        <<~CSV,
+          foo,bar
+          baz,bash
+        CSV
+      )
     end
   end
 end

--- a/spec/google_sheet_spec.rb
+++ b/spec/google_sheet_spec.rb
@@ -8,18 +8,28 @@ RSpec.describe GoogleSheet do
   end
 
   describe "#fetch" do
-    it "returns data if sheet is found" do
-      sheet_id = "1sK8ktAnffewnfiewnfoewifnwoein"
-      range = "Form responses 1!A1:Z"
-      mock_response = %w[foo]
+    let(:sheet_id) { "1sK8ktAnffewnfiewnfoewifnwoein" }
+    let(:mock_sheets_api) do
       mock_sheets_api = instance_double("Google::Apis::SheetsV4::SheetsService")
       allow(mock_sheets_api).to receive(:authorization=)
+      mock_sheets_api
+    end
+
+    it "returns data if sheet is found" do
+      range = "SomeWorksheet!A1:Z"
+      mock_response = %w[foo]
       allow(mock_sheets_api).to receive(:get_spreadsheet_values).with(sheet_id, range).and_return(mock_response)
 
       result = described_class.new(sheets_api: mock_sheets_api)
         .fetch(sheet_id:, range:)
 
       expect(result).to be(mock_response)
+    end
+
+    it "defaults to range 'Form responses 1!A1:Z' (the default worksheet name in spreadsheets linked to Forms)" do
+      expect(mock_sheets_api).to receive(:get_spreadsheet_values).with(sheet_id, "Form responses 1!A1:Z")
+
+      described_class.new(sheets_api: mock_sheets_api).fetch(sheet_id:)
     end
   end
 end

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -3,7 +3,7 @@ require "person"
 RSpec.describe Person do
   let(:person) do
     described_class.new(
-      name: "Dev Eloper",
+      email: "developer@digital.cabinet-office.gov.uk",
       team: "Platform Reliability",
       can_do_roles: %i[
         inhours_primary
@@ -16,9 +16,9 @@ RSpec.describe Person do
     )
   end
 
-  describe "#name" do
-    it "returns the person's name" do
-      expect(person.name).to eq("Dev Eloper")
+  describe "#email" do
+    it "returns the person's email" do
+      expect(person.email).to eq("developer@digital.cabinet-office.gov.uk")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require "byebug"
+require "webmock/rspec"
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
This PR:

- Adds a 'GoogleSheet' class that automates the downloading of the (quarterly) 'developer availability spreadsheet' and the (evergreen) 'technical support sheet'. This is supported by a service account under the hood.
- Adds a 'CsvValidator' class that sense-checks the data returned by the 'developer availability spreadsheet' (which should be in a predictable structure, as we now have a [Google Form Template](https://docs.google.com/forms/d/1PvCMjzCZeELjflHY22p6FH5rtPp3Lvql7LmHGoUSFjM/edit) which we intend to clone whenever we want to send out a new survey of developer availability.

TLDR, it eliminates the need to manually download CSVs and laboriously edit the structure of said CSVs. With the spreadsheet IDs swapped in and the service account key set up, all we need to do is run `ruby bin/combine_csvs.rb` to get the data needed to generate a rota (which we can then generate using `ruby bin/generate_rota.rb`).

Trello: https://trello.com/c/XOcYdbzn/193-remove-csv-manipulation-from-rota-generator