### PR TITLE
Add Pagerduty synchronisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "activesupport"
 gem "google-apis-sheets_v4"
 gem "googleauth"
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "activesupport"
 gem "google-apis-sheets_v4"
 gem "googleauth"
+gem "httparty"
 
 group :test do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     hashdiff (1.1.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -60,6 +63,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.21.2)
     multi_json (1.15.0)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -152,6 +156,7 @@ DEPENDENCIES
   byebug
   google-apis-sheets_v4
   googleauth
+  httparty
   rspec
   rubocop-govuk
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   byebug
   google-apis-sheets_v4
   googleauth

--- a/bin/calculate_fairness.rb
+++ b/bin/calculate_fairness.rb
@@ -7,16 +7,18 @@ ROTA_SHEET_ID = ARGV.first.match(/spreadsheets\/d\/([^\/]+)/)[1]
 TMP_ROTA_CSV = File.dirname(__FILE__) + "/../data/tmp_rota.csv"
 TMP_ROTA_YML = File.dirname(__FILE__) + "/../data/tmp_rota.yml"
 
+roles_config = YAML.load_file("#{File.dirname(__FILE__)}/../config/roles.yml", symbolize_names: true)
+
 puts "Fetching rota..."
 GoogleSheet.new.fetch(sheet_id: ROTA_SHEET_ID, range: "Auto-generated draft rota!A1:Z", filepath: TMP_ROTA_CSV)
 puts "...downloaded to #{TMP_ROTA_CSV}."
 
 puts "Converting to YML..."
-DataProcessor.parse_csv(rota_csv: TMP_ROTA_CSV, rota_yml_output: TMP_ROTA_YML)
+DataProcessor.parse_csv(rota_csv: TMP_ROTA_CSV, roles_config:, rota_yml_output: TMP_ROTA_YML)
 puts "...saved to #{TMP_ROTA_YML}."
 
 puts "Fairness calculator"
 puts RotaPresenter.new(
   people: YAML.load_file(TMP_ROTA_YML, symbolize_names: true)[:people].map { |person_data| Person.new(**person_data) },
   dates: [],
-).fairness_summary(roles_config: YAML.load_file("#{File.dirname(__FILE__)}/../config/roles.yml", symbolize_names: true))
+).fairness_summary(roles_config:)

--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -1,0 +1,103 @@
+require_relative "../lib/pagerduty_client"
+require_relative "../lib/person"
+require_relative "../lib/roles"
+
+rota = YAML.load_file(File.dirname(__FILE__) + "/../data/tmp_rota.yml", symbolize_names: true)
+pd = PagerdutyClient.new(api_token: ENV.fetch("PAGER_DUTY_API_KEY"))
+
+bulk_yes = false
+if ARGV.first == "--bulk"
+  puts "--bulk parameter supplied. Bulk-applying overrides..."
+  bulk_yes = true
+end
+
+puts "Fetching list of users from PagerDuty..."
+users = pd.users
+puts "...fetched."
+
+people = rota[:people].map do |person_data|
+  person = Person.new(
+    email: person_data[:email],
+    team: "Unknown",
+    can_do_roles: [], # unknown - but doesn't matter
+    assigned_shifts: person_data[:assigned_shifts],
+  )
+  pagerduty_user = users.find { |user| user["name"] == person.name }
+  if pagerduty_user
+    person.pagerduty_user_id = pagerduty_user["id"]
+    person
+  else
+    puts "No PagerDuty user found for '#{person.name}' (do they have Production Admin access?). Skipping overriding their shifts..."
+    nil
+  end
+end
+people.compact!
+
+Roles.new.pagerduty_roles.each do |role_id, role_config|
+  puts "Processing #{role_id} shifts..."
+  shifts_to_assign = people.map do |person|
+    person.formatted_shifts(role_id).map { |shift| { person:, **shift } }
+  end
+
+  schedule_id = role_config[:pagerduty][:schedule_id]
+  assigned_shifts_this_schedule = pd.schedule(schedule_id, rota[:dates].first, rota[:dates].last)
+
+  shifts_to_overwrite = shifts_to_assign.flatten.reject do |shift_to_assign|
+    currently_assigned = assigned_shifts_this_schedule.find do |existing_shift|
+      existing_shift["start"] == shift_to_assign[:start_datetime]
+    end
+    currently_assigned && currently_assigned["user"]["summary"] == shift_to_assign[:person].name # person already assigned to this slot
+  end
+
+  puts "Overriding #{shifts_to_overwrite.count} individual shifts in PagerDuty..."
+  shifts_to_overwrite.each do |shift_to_assign|
+    pagerduty_shifts_to_override = assigned_shifts_this_schedule.select do |shift|
+      Time.zone.parse(shift["start"]) >= Time.zone.parse(shift_to_assign[:start_datetime]) &&
+        Time.zone.parse(shift["end"]) <= Time.zone.parse(shift_to_assign[:end_datetime])
+    end
+
+    if pagerduty_shifts_to_override.empty?
+      puts "It was not possible to override #{shift_to_assign} for role #{role_id}."
+      puts "  This means that a past override has merged multiple distinct shifts (e.g. one unbroken shift from in-hours to on-call)."
+      puts "  The rota generator can't currently override 'parts' of an existing shift - it can only override the shift in its entirety."
+      puts "  You will therefore need to manually apply this shift in the PagerDuty UI."
+      next
+    elsif pagerduty_shifts_to_override.count > 1
+      puts "Overriding #{pagerduty_shifts_to_override.count} PagerDuty shifts for this shift."
+    end
+
+    pagerduty_shifts_to_override.each do |existing|
+      puts "Set #{shift_to_assign[:person].name} as the #{role_id} from #{shift_to_assign[:start_datetime]}-#{shift_to_assign[:end_datetime]} (replacing #{existing['user']['summary']})? y/n/exit"
+
+      valid_action = false
+      action = false
+      if bulk_yes
+        action = "y"
+      else
+        while !valid_action
+          action = (gets).chomp
+          valid_action = ["y", "n", "exit"].include?(action)
+          puts "Option #{action.inspect} not recognised" unless valid_action
+        end
+      end
+
+      if action == "y"
+        puts "Overwriting... #{shift_to_assign[:person].pagerduty_user_id} to #{existing["start"]} to #{existing["end"]}"
+        response = pd.create_override(schedule_id, shift_to_assign[:person].pagerduty_user_id, existing["start"], existing["end"])
+
+        if response.code == 400
+          puts "...error applying override."
+          puts response.body
+        else
+          puts "...overwrite applied!"
+        end
+      elsif action == "n"
+        puts "Skipping."
+        next
+      elsif action == "exit"
+        exit
+      end
+    end
+  end
+  puts "Finished overriding #{role_id} shifts."
+end

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -3,11 +3,17 @@ inhours_primary:
   weekdays: true
   weeknights: false
   weekends: false
+  pagerduty:
+    schedule_name: GOV.UK Primary (1st Call)
+    schedule_id: P479TSJ
 inhours_secondary:
   value: 1
   weekdays: true
   weeknights: false
   weekends: false
+  pagerduty:
+    schedule_name: GOV.UK Secondary (2nd Call)
+    schedule_id: P752O37
 inhours_standby_primary:
   value: 0.9
   weekdays: true
@@ -23,8 +29,14 @@ oncall_primary:
   weekdays: false
   weeknights: true
   weekends: true
+  pagerduty:
+    schedule_name: GOV.UK Primary (1st Call)
+    schedule_id: P479TSJ
 oncall_secondary:
   value: 1
   weekdays: false
   weeknights: true
   weekends: true
+  pagerduty:
+    schedule_name: GOV.UK Secondary (2nd Call)
+    schedule_id: P752O37

--- a/lib/data_processor.rb
+++ b/lib/data_processor.rb
@@ -148,7 +148,7 @@ class DataProcessor
     end
   end
 
-  def self.parse_csv(rota_csv:, rota_yml_output:)
+  def self.parse_csv(rota_csv:, roles_config:, rota_yml_output:)
     rota_csv = CSV.read(rota_csv, headers: true)
 
     people_data = {}
@@ -170,6 +170,8 @@ class DataProcessor
         people_data[name] = { assigned_shifts: [] } unless people_data[name]
         date_range(*week_data["week"].split("-")).each do |date|
           next if overrides.find { |override| override[:date] == date }
+
+          next if !roles_config[role.to_sym][:weekends] && %w[Saturday Sunday].include?(Date.parse(date).strftime("%A"))
 
           people_data[name][:assigned_shifts] << { role: role.to_sym, date: }
         end

--- a/lib/pagerduty_client.rb
+++ b/lib/pagerduty_client.rb
@@ -1,0 +1,73 @@
+require "active_support"
+require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/time/zones"
+require "httparty"
+Time.zone = "Europe/London"
+
+class PagerdutyClient
+  #  PagerDuty's maximum: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTU4-pagination#classic-pagination
+  API_LIMIT = 100
+
+  def initialize(api_token:)
+    raise "Missing PagerDuty API token" unless api_token
+
+    @api_token = api_token
+  end
+
+  def users
+    offset = 0
+    users = []
+    loop do
+      batch_results = HTTParty.get(
+        "https://api.pagerduty.com/users?limit=#{API_LIMIT}&offset=#{offset}",
+        headers: {
+          "Content-Type" => "application/json",
+          "Accept" => "application/vnd.pagerduty+json;version=2",
+          "Authorization" => "Token token=#{@api_token}",
+        },
+      )
+      users << batch_results["users"]
+      break unless batch_results["more"]
+
+      offset += API_LIMIT
+    end
+    users.flatten
+  end
+
+  def schedule(schedule_id, from_date, to_date)
+    since_datetime = Time.zone.parse(from_date).iso8601
+    until_datetime = (Time.zone.parse(to_date) + 1.day).iso8601
+
+    HTTParty.get(
+      "https://api.pagerduty.com/schedules/#{schedule_id}?since=#{since_datetime}&until=#{until_datetime}",
+      headers: {
+        "Content-Type" => "application/json",
+        "Accept" => "application/vnd.pagerduty+json;version=2",
+        "Authorization" => "Token token=#{@api_token}",
+      },
+    )["schedule"]["final_schedule"]["rendered_schedule_entries"]
+  end
+
+  def create_override(schedule_id, pagerduty_user_id, start_datetime, end_datetime)
+    override = {
+      override: {
+        start: start_datetime,
+        end: end_datetime,
+        user: {
+          id: pagerduty_user_id,
+          type: "user_reference",
+        },
+      },
+    }
+
+    HTTParty.post(
+      "https://api.pagerduty.com/schedules/#{schedule_id}/overrides",
+      body: override.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+        "Accept" => "application/vnd.pagerduty+json;version=2",
+        "Authorization" => "Token token=#{@api_token}",
+      },
+    )
+  end
+end

--- a/lib/person.rb
+++ b/lib/person.rb
@@ -7,6 +7,7 @@ class MultipleRolesException < StandardError; end
 class ShiftNotAssignedException < StandardError; end
 
 class Person
+  attr_accessor :pagerduty_user_id
   attr_reader :email, :team, :can_do_roles, :non_working_days, :assigned_shifts
 
   def initialize(email:, team:, can_do_roles:, forbidden_in_hours_days: [], forbidden_on_call_days: [], non_working_days: [], assigned_shifts: [])

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -24,4 +24,8 @@ class Roles
     end
     values.sum.round(2)
   end
+
+  def pagerduty_roles
+    @config.select { |_key, config| config[:pagerduty] }
+  end
 end

--- a/lib/roles.rb
+++ b/lib/roles.rb
@@ -1,4 +1,9 @@
+require "active_support"
+require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/time/zones"
 require "yaml"
+
+Time.zone = "Europe/London"
 
 class Roles
   attr_reader :config
@@ -27,5 +32,26 @@ class Roles
 
   def pagerduty_roles
     @config.select { |_key, config| config[:pagerduty] }
+  end
+
+  def start_datetime(date, role)
+    parsed_date = Time.zone.parse(date)
+    day_of_week = parsed_date.strftime("%A")
+    start_of_day = (parsed_date + 9.5.hours).iso8601
+    end_of_day = (parsed_date + 17.5.hours).iso8601
+
+    if @config[role][:weeknights] && %w[Monday Tuesday Wednesday Thursday Friday].include?(day_of_week)
+      end_of_day
+    else
+      start_of_day
+    end
+  end
+
+  def end_datetime(date, role)
+    parsed_date = Time.zone.parse(date)
+    end_of_day = (parsed_date + 17.5.hours).iso8601
+    start_of_next_day = (parsed_date + 1.day + 9.5.hours).iso8601
+
+    @config[role][:weekdays] ? end_of_day : start_of_next_day
   end
 end

--- a/spec/data_processor_spec.rb
+++ b/spec/data_processor_spec.rb
@@ -1,4 +1,5 @@
 require "csv"
+require "yaml"
 require "data_processor"
 
 RSpec.describe DataProcessor do
@@ -162,12 +163,13 @@ RSpec.describe DataProcessor do
   describe ".parse_csv" do
     it "converts a CSV representation of a rota into the YML structure used by govuk-rota-generator" do
       draft_csv = "#{File.dirname(__FILE__)}/fixtures/data_processor/parse_csv/draft_rota.csv"
+      roles_config = YAML.load_file("#{File.dirname(__FILE__)}/fixtures/data_processor/parse_csv/roles.yml", symbolize_names: true)
       expected_output = "#{File.dirname(__FILE__)}/fixtures/data_processor/parse_csv/draft_rota.yml"
 
       filepath = "#{File.dirname(__FILE__)}/tmp/local.yml"
       File.delete(filepath) if File.exist? filepath
 
-      described_class.parse_csv(rota_csv: draft_csv, rota_yml_output: filepath)
+      described_class.parse_csv(rota_csv: draft_csv, roles_config:, rota_yml_output: filepath)
       expect(File.read(filepath)).to eq(File.read(expected_output))
     end
   end

--- a/spec/fixtures/data_processor/parse_csv/draft_rota.yml
+++ b/spec/fixtures/data_processor/parse_csv/draft_rota.yml
@@ -34,10 +34,6 @@ people:
     date: 04/04/2024
   - role: :inhours_primary
     date: 05/04/2024
-  - role: :inhours_primary
-    date: 06/04/2024
-  - role: :inhours_primary
-    date: 07/04/2024
   - role: :inhours_secondary
     date: '08/04/2024'
   - role: :inhours_secondary
@@ -48,10 +44,6 @@ people:
     date: 11/04/2024
   - role: :inhours_secondary
     date: 12/04/2024
-  - role: :inhours_secondary
-    date: 13/04/2024
-  - role: :inhours_secondary
-    date: 14/04/2024
 - email: sam.smith@digital.cabinet-office.gov.uk
   team: Unknown
   non_working_days: []
@@ -70,10 +62,6 @@ people:
     date: 04/04/2024
   - role: :inhours_secondary
     date: 05/04/2024
-  - role: :inhours_secondary
-    date: 06/04/2024
-  - role: :inhours_secondary
-    date: 07/04/2024
 - email: jonny.james@digital.cabinet-office.gov.uk
   team: Unknown
   non_working_days: []
@@ -92,10 +80,6 @@ people:
     date: 04/04/2024
   - role: :inhours_standby_primary
     date: 05/04/2024
-  - role: :inhours_standby_primary
-    date: 06/04/2024
-  - role: :inhours_standby_primary
-    date: 07/04/2024
 - email: phil.c@digital.cabinet-office.gov.uk
   team: Unknown
   non_working_days: []
@@ -114,10 +98,6 @@ people:
     date: 04/04/2024
   - role: :inhours_standby_secondary
     date: 05/04/2024
-  - role: :inhours_standby_secondary
-    date: 06/04/2024
-  - role: :inhours_standby_secondary
-    date: 07/04/2024
 - email: jamie.jameson@digital.cabinet-office.gov.uk
   team: Unknown
   non_working_days: []
@@ -176,10 +156,6 @@ people:
     date: 11/04/2024
   - role: :inhours_primary
     date: 12/04/2024
-  - role: :inhours_primary
-    date: 13/04/2024
-  - role: :inhours_primary
-    date: 14/04/2024
 - email: carl.e@digital.cabinet-office.gov.uk
   team: Unknown
   non_working_days: []
@@ -218,10 +194,6 @@ people:
     date: 11/04/2024
   - role: :inhours_standby_primary
     date: 12/04/2024
-  - role: :inhours_standby_primary
-    date: 13/04/2024
-  - role: :inhours_standby_primary
-    date: 14/04/2024
 - email: bob.builder@digital.cabinet-office.gov.uk
   team: Unknown
   non_working_days: []

--- a/spec/fixtures/data_processor/parse_csv/roles.yml
+++ b/spec/fixtures/data_processor/parse_csv/roles.yml
@@ -1,0 +1,30 @@
+inhours_primary:
+  value: 1
+  weekdays: true
+  weeknights: false
+  weekends: false
+inhours_secondary:
+  value: 1
+  weekdays: true
+  weeknights: false
+  weekends: false
+inhours_standby_primary:
+  value: 0.9
+  weekdays: true
+  weeknights: false
+  weekends: false
+inhours_standby_secondary:
+  value: 0.9
+  weekdays: true
+  weeknights: false
+  weekends: false
+oncall_primary:
+  value: 1
+  weekdays: false
+  weeknights: true
+  weekends: true
+oncall_secondary:
+  value: 1
+  weekdays: false
+  weeknights: true
+  weekends: true

--- a/spec/pagerduty_client_spec.rb
+++ b/spec/pagerduty_client_spec.rb
@@ -1,0 +1,194 @@
+require "pagerduty_client"
+
+RSpec.describe PagerdutyClient do
+  let(:user) do
+    {
+      "id" => "P69OQXR",
+      "name" => "Some User",
+      "email" => "some-user@digital.cabinet-office.gov.uk",
+      "teams" => [
+        {
+          "id" => "PG4Z8YR",
+          "type" => "team_reference",
+          "summary" => "GOV.UK",
+        },
+      ],
+    }
+  end
+
+  describe ".initialize" do
+    it "takes an API token" do
+      described_class.new(api_token: "foo")
+    end
+
+    it "raises an error if token is nil" do
+      expect { described_class.new(api_token: nil) }.to raise_exception("Missing PagerDuty API token")
+    end
+  end
+
+  describe "#users" do
+    it "paginates through the list of users" do
+      request_1 = stub_request(:get, "https://api.pagerduty.com/users?limit=100&offset=0")
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            users: [
+              user,
+              # imagine there are 99 more
+            ],
+            limit: 100,
+            offset: 0,
+            more: true,
+          }.to_json,
+        )
+      request_2 = stub_request(:get, "https://api.pagerduty.com/users?limit=100&offset=100")
+        .to_return(
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            users: [
+              user, # pretend this is a different user to the one from the first request. It doesn't really matter.
+              # as before, imagine there are up to 99 more
+            ],
+            limit: 100,
+            offset: 100,
+            more: false,
+          }.to_json,
+        )
+
+      pd = described_class.new(api_token: "foo")
+      expect(pd.users).to eq([user, user])
+      expect(request_1).to have_been_requested
+      expect(request_2).to have_been_requested
+    end
+  end
+
+  describe "#schedule" do
+    it "retrieves a specific schedule between two dates" do
+      schedule_id = "P999ABC"
+      from_date = "01/04/2024"
+      to_date = "07/04/2024"
+      rendered_schedule_entries = [
+        {
+          # on-call person 'carried over' from previous week
+          start: "2024-04-01T00:00:00+01:00",
+          end: "2024-04-01T09:30:00+01:00",
+          user: {
+            id: "PRTM7I7",
+            summary: "Andrew O'Neil",
+          },
+          id: "Q00SXW3CI01234",
+        },
+        {
+          # beginning of new week in-hours (Monday)
+          start: "2024-04-01T09:30:00+01:00",
+          end: "2024-04-01T17:30:00+01:00",
+          user: {
+            id: "PRTM7I8",
+            summary: "Someone else",
+          },
+          id: "Q00SXW3CI02345",
+        },
+        {
+          # beginning of new week on-call (Monday overnight)
+          start: "2024-04-01T17:30:00+01:00",
+          end: "2024-04-02T09:30:00+01:00",
+          user: {
+            id: "PRTM7I9",
+            summary: "Another person",
+          },
+          id: "Q00SXW3CI04567",
+        },
+        {
+          # Tuesday
+          start: "2024-04-02T09:30:00+01:00",
+          end: "2024-04-02T17:30:00+01:00",
+          user: {
+            id: "PRTM7I8",
+            summary: "Someone else",
+          },
+          id: "Q00SXW3CI02345",
+        },
+        {
+          # Tuesday overnight
+          start: "2024-04-02T17:30:00+01:00",
+          end: "2024-04-03T09:30:00+01:00",
+          user: {
+            id: "PRTM7I9",
+            summary: "Another person",
+          },
+          id: "Q00SXW3CI04567",
+        },
+        # ...and so on
+        {
+          # last day of week
+          start: "2024-04-05T09:30:00+01:00",
+          end: "2024-04-05T17:30:00+01:00",
+          user: {
+            id: "PRTM7I8",
+            summary: "Someone else",
+          },
+          id: "Q00SXW3CI02345",
+        },
+        {
+          # last on-call of week, including weekend shift
+          # (actual on-call shift continues until 9:30 on 8th April,
+          # but only goes to midnight here as that is the limit we've
+          # specified with the `until` URL param)
+          start: "2024-04-05T17:30:00+01:00",
+          end: "2024-04-08T00:00:00+01:00",
+          user: {
+            id: "PRTM7I9",
+            summary: "Another person",
+          },
+          id: "Q00SXW3CI04567",
+        },
+      ]
+      api_response = {
+        schedule: {
+          final_schedule: {
+            rendered_schedule_entries:,
+          },
+        },
+      }
+
+      stub_request(
+        :get,
+        "https://api.pagerduty.com/schedules/#{schedule_id}?since=2024-04-01T00:00:00%2001:00&until=2024-04-08T00:00:00%2001:00",
+      ).to_return(
+        headers: { "Content-Type" => "application/json" },
+        body: api_response.to_json,
+      )
+
+      pd = described_class.new(api_token: "foo")
+      expect(pd.schedule(schedule_id, from_date, to_date).to_json).to eq(rendered_schedule_entries.to_json)
+    end
+  end
+
+  describe "#create_override" do
+    it "sends an override request to PagerDuty" do
+      schedule_id = "P999ABC"
+      pagerduty_user_id = "foo"
+      start_datetime = "2024-04-05T17:30:00+01:00"
+      end_datetime = "2024-04-08T00:00:00+01:00"
+
+      post_request = stub_request(:post, "https://api.pagerduty.com/schedules/P999ABC/overrides")
+        .with(
+          body: {
+            override: {
+              start: start_datetime,
+              end: end_datetime,
+              user: {
+                id: pagerduty_user_id,
+                type: "user_reference",
+              },
+            },
+          }.to_json,
+        ).to_return(status: 200, body: "", headers: {})
+
+      pd = described_class.new(api_token: "foo")
+      pd.create_override(schedule_id, pagerduty_user_id, start_datetime, end_datetime)
+
+      expect(post_request).to have_been_requested
+    end
+  end
+end

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -176,6 +176,34 @@ RSpec.describe Person do
     end
   end
 
+  describe "#formatted_shifts" do
+    it "takes an optional argument to specify the shift type" do
+      person.assign(role: :inhours_primary, date: "08/04/2024")
+      person.assign(role: :oncall_primary, date: "09/04/2024")
+
+      expect(person.formatted_shifts(:oncall_primary)).to eq([
+        {
+          role: :oncall_primary,
+          start_datetime: "2024-04-09T17:30:00+01:00",
+          end_datetime: "2024-04-10T09:30:00+01:00",
+        },
+      ])
+    end
+
+    it "merges shifts when there is no gap between them" do
+      person.assign(role: :oncall_primary, date: "12/04/2024") # Friday
+      person.assign(role: :oncall_primary, date: "13/04/2024") # Saturday
+      person.assign(role: :oncall_primary, date: "14/04/2024") # Saturday
+      expect(person.formatted_shifts).to eq([
+        {
+          role: :oncall_primary,
+          start_datetime: "2024-04-12T17:30:00+01:00",
+          end_datetime: "2024-04-15T09:30:00+01:00",
+        },
+      ])
+    end
+  end
+
   describe "#to_h" do
     it "returns all the metadata about the person needed to generate a rota" do
       expected_hash = person_configuration

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe Person do
     end
   end
 
+  describe "#pagerduty_user_id" do
+    it "can get and set a pagerduty_user_id" do
+      expect(person.pagerduty_user_id).to eq(nil)
+      person.pagerduty_user_id = "foo"
+      expect(person.pagerduty_user_id).to eq("foo")
+    end
+  end
+
   describe "#team" do
     it "returns the person's team" do
       expect(person.team).to eq("Platform Reliability")

--- a/spec/roles_spec.rb
+++ b/spec/roles_spec.rb
@@ -88,4 +88,30 @@ RSpec.describe Roles do
       expect(roles.value_of_shifts(shifts)).to eq(4)
     end
   end
+
+  describe "#pagerduty_roles" do
+    it "returns all the role IDs of roles that should correspond to a specific schedule in Pagerduty" do
+      pagerduty_role = {
+        value: 2,
+        weekdays: true,
+        weeknights: false,
+        weekends: false,
+        pagerduty: {
+          schedule_name: "GOV.UK Secondary (2nd Call)",
+          schedule_id: "P752O37",
+        },
+      }
+      roles_config = {
+        foo: {
+          value: 2,
+          weekdays: true,
+          weeknights: false,
+          weekends: false,
+        },
+        bar: pagerduty_role,
+      }
+      roles = described_class.new(config: roles_config)
+      expect(roles.pagerduty_roles).to eq({ bar: pagerduty_role })
+    end
+  end
 end

--- a/spec/roles_spec.rb
+++ b/spec/roles_spec.rb
@@ -114,4 +114,46 @@ RSpec.describe Roles do
       expect(roles.pagerduty_roles).to eq({ bar: pagerduty_role })
     end
   end
+
+  describe "#start_datetime" do
+    it "returns start datetime for given date and role type" do
+      roles_config = {
+        inhours: {
+          weekdays: true,
+          weeknights: false,
+          weekends: false,
+        },
+        oncall: {
+          weekdays: false,
+          weeknights: true,
+          weekends: true,
+        },
+      }
+      roles = described_class.new(config: roles_config)
+      expect(roles.start_datetime("08/04/2024", :inhours)).to eq("2024-04-08T09:30:00+01:00") # Monday in-hours 9:30-5:30
+      expect(roles.start_datetime("08/04/2024", :oncall)).to eq("2024-04-08T17:30:00+01:00") # Monday on-call 5:30-9:30
+      expect(roles.start_datetime("13/04/2024", :oncall)).to eq("2024-04-13T09:30:00+01:00") # Saturday on-call 9:30am Sat -> 9:30am Sun
+    end
+  end
+
+  describe "#end_datetime" do
+    it "returns end datetime for given date and role type" do
+      roles_config = {
+        inhours: {
+          weekdays: true,
+          weeknights: false,
+          weekends: false,
+        },
+        oncall: {
+          weekdays: false,
+          weeknights: true,
+          weekends: true,
+        },
+      }
+      roles = described_class.new(config: roles_config)
+      expect(roles.end_datetime("08/04/2024", :inhours)).to eq("2024-04-08T17:30:00+01:00") # Monday in-hours 9:30-5:30
+      expect(roles.end_datetime("08/04/2024", :oncall)).to eq("2024-04-09T09:30:00+01:00") # Monday on-call 5:30-9:30
+      expect(roles.end_datetime("13/04/2024", :oncall)).to eq("2024-04-14T09:30:00+01:00") # Saturday on-call 9:30am Sat -> 9:30am Sun
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a script that synchronises a govuk-rota-generator generated rota with PagerDuty.

Once merged, we can retire [pay-pagerduty](https://github.com/alphagov/pay-pagerduty), which will no longer be used. We did consider editing pay-pagerduty itself, but changing from weekly to daily shifts was too big a job and it ended up being easier to cherry-pick the relevant PagerDuty API scripts and put them into govuk-rota-generator. Keeping the two features under one repo also provides room for improvements in future (e.g. automatic pagerduty sync on rota generation).

Trello: https://trello.com/c/a7751qyu/198-write-pagerduty-sync-script-for-rota-generator