### PR TITLE
Give CI workflow the name "CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
This is [now a requirement](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#name-of-ci-workflow-and-jobs). Omitting it [causes govuk-dependabot-merger to avoid auto-merging PRs for the repo](https://github.com/alphagov/govuk-dependabot-merger/actions/runs/8388249626/job/22972042090).

Merging this will let #36 auto-merge on next run.