### PR TITLE
Rota generator tweaks for Q2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 # govuk-rota-generator
 
-Generates a balanced rota, taking into account each developer's availability and eligibility for different cover types.
+Generates a balanced rota, taking into account:
 
-There are some limitations to the generator, which we hope to resolve in future iterations:
-
-1. Currently no way of capping certain shift types.
-1. It doesn't account for different working patterns (e.g. devs who don't work Fridays currently have to find cover)
-1. The week is marked as 'unavailable' even if only one cover type is off limits. For example, a developer may say they're unavailable to do on-call at the weekend, but they would still be available to do in-hours shifts.
-1. It doesn't account for bank holidays.
-1. It doesn't account for team burden (i.e. there's nothing preventing it allocating multiple devs from the same team on one shift).
-1. It doesn't give a perfectly balanced rota (some devs will be allocated more slots than others), but a 'balancing' step after a first pass could be something we look at in future.
-
-We hope one day to make the rota generator think in terms of days rather than weeks, and also have tighter integration with the `pay-pagerduty` repo (e.g. merging together under a new name).
+1. Each developer's availability and eligibility for different cover types.
+1. Team burden (it avoids allocating multiple devs from the same team on one shift).
+1. Different working patterns (e.g. devs who don't work Fridays will automatically have cover assigned for that day).
+1. Partial availability (e.g. a developer may say they're unavailable to do on-call at the weekend, but they would still be available to do in-hours shifts - the generator will make use of that).
+1. Bank holiday support - it uses the [GOV.UK bank holiday API](https://www.gov.uk/bank-holidays.json) to detect bank holidays and ensure that the assigned on-call person that week is given the 'in-hours' shift in PagerDuty.
 
 ## Setup
 

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -14,12 +14,7 @@ inhours_secondary:
   pagerduty:
     schedule_name: GOV.UK Secondary (2nd Call)
     schedule_id: P752O37
-inhours_standby_primary:
-  value: 0.9
-  weekdays: true
-  weeknights: false
-  weekends: false
-inhours_standby_secondary:
+inhours_standby:
   value: 0.9
   weekdays: true
   weeknights: false

--- a/lib/data_processor.rb
+++ b/lib/data_processor.rb
@@ -53,8 +53,7 @@ class DataProcessor
         can_do_roles: [
           person_data["Eligible for in-hours primary?"] == "Yes" ? :inhours_primary : nil,
           person_data["Can do in-hours secondary?"] == "Yes" ? :inhours_secondary : nil,
-          person_data["Eligible for in-hours primary?"] == "Yes" ? :inhours_standby_primary : nil,
-          person_data["Can do in-hours secondary?"] == "Yes" ? :inhours_standby_secondary : nil,
+          person_data["Can do in-hours secondary?"] == "Yes" ? :inhours_standby : nil,
           person_data["Should be scheduled for on-call?"] == "Yes" && person_data["Eligible for on-call primary?"] == "Yes" ? :oncall_primary : nil,
           person_data["Should be scheduled for on-call?"] == "Yes" && person_data["Eligible for on-call secondary?"] == "Yes" ? :oncall_secondary : nil,
         ].compact,

--- a/lib/person.rb
+++ b/lib/person.rb
@@ -43,13 +43,15 @@ class Person
     available_roles
   end
 
-  def assign(role:, date:)
-    if (conflicting_shift = @assigned_shifts.find { |shift| shift[:date] == date })
+  def assign(role:, date:, force: false)
+    if (conflicting_shift = @assigned_shifts.find { |shift| shift[:date] == date }) && !force
       raise MultipleRolesException, "Failed to assign role #{role} to #{email} on date #{date} as they're already assigned to #{conflicting_shift[:role]}"
     end
 
-    raise ForbiddenRoleException unless can_do_role?(role)
-    raise ForbiddenDateException unless availability(date:).include?(role)
+    unless force
+      raise ForbiddenRoleException unless can_do_role?(role)
+      raise ForbiddenDateException unless availability(date:).include?(role)
+    end
 
     @assigned_shifts << { date:, role: }
 

--- a/lib/rota_presenter.rb
+++ b/lib/rota_presenter.rb
@@ -62,7 +62,7 @@ class RotaPresenter
           end
 
           grouped = people_covering_role_this_week.group_by { |shift| shift[:name] }
-          name_of_person_with_most_shifts = grouped.keys.first
+          name_of_person_with_most_shifts = grouped.max { |a, b| a[1].count <=> b[1].count }[0]
           if grouped.count == 1
             name_of_person_with_most_shifts
           else

--- a/spec/data_processor_spec.rb
+++ b/spec/data_processor_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe DataProcessor do
         can_do_roles: %i[
           inhours_primary
           inhours_secondary
-          inhours_standby_primary
-          inhours_standby_secondary
+          inhours_standby
           oncall_primary
           oncall_secondary
         ],
@@ -64,8 +63,7 @@ RSpec.describe DataProcessor do
         can_do_roles: %i[
           inhours_primary
           inhours_secondary
-          inhours_standby_primary
-          inhours_standby_secondary
+          inhours_standby
           oncall_primary
           oncall_secondary
         ],

--- a/spec/fixtures/data_processor/combine_csvs/rota_inputs.yml
+++ b/spec/fixtures/data_processor/combine_csvs/rota_inputs.yml
@@ -99,8 +99,7 @@ people:
   can_do_roles:
   - :inhours_primary
   - :inhours_secondary
-  - :inhours_standby_primary
-  - :inhours_standby_secondary
+  - :inhours_standby
   - :oncall_primary
   - :oncall_secondary
   forbidden_in_hours_days:

--- a/spec/fixtures/data_processor/parse_csv/draft_rota.csv
+++ b/spec/fixtures/data_processor/parse_csv/draft_rota.csv
@@ -1,3 +1,3 @@
-week,inhours_primary,inhours_secondary,inhours_standby_primary,inhours_standby_secondary,oncall_primary,oncall_secondary
-01/04/2024-07/04/2024,Joe Bloggs,Sam Smith,Jonny James,Phil C,Jamie Jameson,Maxine Maxon
-08/04/2024-14/04/2024,"Dev Eloper (Carl E on 09/04/2024, Jo C on 10/04/2024)",Joe Bloggs,Kenny Kennedy,,Bob Builder,Arnold Arnie
+week,inhours_primary,inhours_secondary,inhours_standby,oncall_primary,oncall_secondary
+01/04/2024-07/04/2024,Joe Bloggs,Sam Smith,Jonny James,Jamie Jameson,Maxine Maxon
+08/04/2024-14/04/2024,"Dev Eloper (Carl E on 09/04/2024, Jo C on 10/04/2024)",Joe Bloggs,Kenny Kennedy,Bob Builder,Arnold Arnie

--- a/spec/fixtures/data_processor/parse_csv/draft_rota.yml
+++ b/spec/fixtures/data_processor/parse_csv/draft_rota.yml
@@ -66,37 +66,19 @@ people:
   team: Unknown
   non_working_days: []
   can_do_roles:
-  - :inhours_standby_primary
+  - :inhours_standby
   forbidden_in_hours_days: []
   forbidden_on_call_days: []
   assigned_shifts:
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 01/04/2024
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 02/04/2024
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 03/04/2024
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 04/04/2024
-  - role: :inhours_standby_primary
-    date: 05/04/2024
-- email: phil.c@digital.cabinet-office.gov.uk
-  team: Unknown
-  non_working_days: []
-  can_do_roles:
-  - :inhours_standby_secondary
-  forbidden_in_hours_days: []
-  forbidden_on_call_days: []
-  assigned_shifts:
-  - role: :inhours_standby_secondary
-    date: 01/04/2024
-  - role: :inhours_standby_secondary
-    date: 02/04/2024
-  - role: :inhours_standby_secondary
-    date: 03/04/2024
-  - role: :inhours_standby_secondary
-    date: 04/04/2024
-  - role: :inhours_standby_secondary
+  - role: :inhours_standby
     date: 05/04/2024
 - email: jamie.jameson@digital.cabinet-office.gov.uk
   team: Unknown
@@ -180,19 +162,19 @@ people:
   team: Unknown
   non_working_days: []
   can_do_roles:
-  - :inhours_standby_primary
+  - :inhours_standby
   forbidden_in_hours_days: []
   forbidden_on_call_days: []
   assigned_shifts:
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: '08/04/2024'
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: '09/04/2024'
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 10/04/2024
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 11/04/2024
-  - role: :inhours_standby_primary
+  - role: :inhours_standby
     date: 12/04/2024
 - email: bob.builder@digital.cabinet-office.gov.uk
   team: Unknown

--- a/spec/fixtures/data_processor/parse_csv/roles.yml
+++ b/spec/fixtures/data_processor/parse_csv/roles.yml
@@ -8,12 +8,7 @@ inhours_secondary:
   weekdays: true
   weeknights: false
   weekends: false
-inhours_standby_primary:
-  value: 0.9
-  weekdays: true
-  weeknights: false
-  weekends: false
-inhours_standby_secondary:
+inhours_standby:
   value: 0.9
   weekdays: true
   weeknights: false

--- a/spec/fixtures/generated_rota.yml
+++ b/spec/fixtures/generated_rota.yml
@@ -47,12 +47,8 @@ people:
     role: :oncall_primary
   - date: 03/04/2024
     role: :oncall_primary
-  - date: 04/04/2024
-    role: :oncall_primary
   - date: 05/04/2024
     role: :inhours_primary
-  - date: 05/04/2024
-    role: :oncall_primary
   - date: '08/04/2024'
     role: :inhours_primary
   - date: '09/04/2024'
@@ -71,6 +67,10 @@ people:
   forbidden_in_hours_days: []
   forbidden_on_call_days: []
   assigned_shifts:
+  - date: 04/04/2024
+    role: :oncall_primary
+  - date: 05/04/2024
+    role: :oncall_primary
   - date: 06/04/2024
     role: :oncall_primary
   - date: 07/04/2024

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -125,9 +125,10 @@ RSpec.describe Person do
       expect { person.assign(role: :oncall_secondary, date: "08/04/2024") }.to raise_exception(ForbiddenRoleException)
     end
 
-    it "raises an error when assigning multiple supported roles on an available date" do
+    it "raises an error when assigning multiple supported roles on an available date (unless `force: true` is passed)" do
       expect { person.assign(role: :inhours_primary, date: "08/04/2024") }.not_to raise_exception
       expect { person.assign(role: :inhours_secondary, date: "08/04/2024") }.to raise_exception(MultipleRolesException)
+      expect { person.assign(role: :inhours_secondary, date: "08/04/2024", force: true) }.not_to raise_exception
     end
   end
 

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Person do
       can_do_roles: %i[
         inhours_primary
         inhours_secondary
-        inhours_standby_primary
-        inhours_standby_secondary
+        inhours_standby
         oncall_primary
       ],
       forbidden_in_hours_days: [
@@ -74,7 +73,7 @@ RSpec.describe Person do
   describe "#can_do_role?" do
     it "returns `true` for roles that the person can do" do
       expect(person.can_do_role?(:inhours_primary)).to eq(true)
-      expect(person.can_do_role?(:inhours_standby_secondary)).to eq(true)
+      expect(person.can_do_role?(:inhours_standby)).to eq(true)
     end
 
     it "returns `false` for roles that the person cannot do" do
@@ -87,8 +86,7 @@ RSpec.describe Person do
       expect(person.availability(date: "08/04/2024")).to eq(%i[
         inhours_primary
         inhours_secondary
-        inhours_standby_primary
-        inhours_standby_secondary
+        inhours_standby
         oncall_primary
       ])
     end

--- a/spec/rota_presenter_spec.rb
+++ b/spec/rota_presenter_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe RotaPresenter do
           01/04/2024,A,B
           02/04/2024,A,B
           03/04/2024,A,B
-          04/04/2024,A,B
-          05/04/2024,B,B
+          04/04/2024,A,C
+          05/04/2024,B,C
           06/04/2024,"",C
           07/04/2024,"",C
           08/04/2024,B,C
@@ -57,13 +57,13 @@ RSpec.describe RotaPresenter do
   end
 
   describe "#to_csv_weekly" do
-    it "outputs the rota as a CSV, grouped by week" do
+    it "outputs the rota as a CSV, grouped by week, each role showing the person with the most shifts that week (and daily overrides provided in parentheses)" do
       presenter = described_class.new(filepath: "#{File.dirname(__FILE__)}/fixtures/generated_rota.yml")
 
       expect(presenter.to_csv_weekly).to eq(
         <<~CSV.chomp,
           week,inhours_primary,oncall_primary
-          01/04/2024-07/04/2024,A (B on 05/04/2024),"B (C on 06/04/2024, C on 07/04/2024)"
+          01/04/2024-07/04/2024,A (B on 05/04/2024),"C (B on 01/04/2024, B on 02/04/2024, B on 03/04/2024)"
           08/04/2024-14/04/2024,B,C
 
         CSV
@@ -94,8 +94,8 @@ RSpec.describe RotaPresenter do
 
       expect(presenter.fairness_summary(roles_config:)).to eq(
         <<~OUTPUT.chomp,
-          C has 18 units of inconvenience, made up of 9 shifts including 9 oncall_primary.
-          B has 16 units of inconvenience, made up of 11 shifts including 5 oncall_primary, 6 inhours_primary.
+          C has 22 units of inconvenience, made up of 11 shifts including 11 oncall_primary.
+          B has 12 units of inconvenience, made up of 9 shifts including 3 oncall_primary, 6 inhours_primary.
           A has 4 units of inconvenience, made up of 4 shifts including 4 inhours_primary.
         OUTPUT
       )


### PR DESCRIPTION
- Only assign one standby, not two, to reflect the reduced scope of 2nd line
- Better presentation of 'split shifts', particularly when someone (let's call them Fred) with a non-working day of Monday is assigned the week. Previously it would show the "override's" name by default, and then Fred's name repeated four times to cover the rest of the week. It now shows Fred's name by default and only the override in parentheses.
- Assign the on-call devs to the in-hours bank holiday shifts (which is much less surprising than the in-hours folks being assigned in Pagerduty!)

Trello card: https://trello.com/c/7gQtBicC/205-create-the-2nd-line-rota-for-q2