### PR TITLE
Have 'calculate fairness' script check 'manually tweaked' rota

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Note that you can tweak the weighting of each 'role' (e.g. `oncall_primary`) by 
 
 Run `ruby bin/calculate_fairness.rb https://docs.google.com/spreadsheets/d/abc123def456hij789/edit`.
 
-This summarises the fairness of the rota at the "Auto-generated draft rota" worksheet you set up earlier.
+This summarises the fairness of the rota. It looks for a "Manually tweaked rota" worksheet, so you'll first need to copy the "Auto-generated draft rota" into a new "Manually tweaked rota" worksheet in the same spreadsheet, and copy over the data. This allows you to freely tweak the output of the rota, without worrying about losing all of your changes next time you run the rota generator.
 
 ### Synchronise the rota with PagerDuty
 

--- a/bin/calculate_fairness.rb
+++ b/bin/calculate_fairness.rb
@@ -10,7 +10,7 @@ TMP_ROTA_YML = "#{File.dirname(__FILE__)}/../data/tmp_rota.yml".freeze
 roles_config = YAML.load_file("#{File.dirname(__FILE__)}/../config/roles.yml", symbolize_names: true)
 
 puts "Fetching rota..."
-GoogleSheet.new.fetch(sheet_id: ROTA_SHEET_ID, range: "Auto-generated draft rota!A1:Z", filepath: TMP_ROTA_CSV)
+GoogleSheet.new.fetch(sheet_id: ROTA_SHEET_ID, range: "Manually tweaked rota!A1:Z", filepath: TMP_ROTA_CSV)
 puts "...downloaded to #{TMP_ROTA_CSV}."
 
 puts "Converting to YML..."


### PR DESCRIPTION
In practice, we copy over the auto-generated rota to a separate "manually tweaked rota" worksheet tab, so that we can make manual edits to the rota to make it account for things that the rota generator does not know about or yet support.