### PR TITLE
Fix PagerDuty overriding for end-of-quarter on-call shifts

### DIFF
--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -49,10 +49,11 @@ Roles.new.pagerduty_roles.each do |role_id, role_config|
 
   puts "Overriding #{shifts_to_overwrite.count} individual shifts in PagerDuty..."
   shifts_to_overwrite.each do |shift_to_assign|
-    pagerduty_shifts_to_override = assigned_shifts_this_schedule.select do |shift|
-      Time.zone.parse(shift["start"]) >= Time.zone.parse(shift_to_assign[:start_datetime]) &&
-        Time.zone.parse(shift["end"]) <= Time.zone.parse(shift_to_assign[:end_datetime])
-    end
+    pagerduty_shifts_to_override = pd.shifts_within_timespan(
+      shift_to_assign[:start_datetime],
+      shift_to_assign[:end_datetime],
+      assigned_shifts_this_schedule,
+    )
 
     if pagerduty_shifts_to_override.empty?
       # TODO: this message can happen when someone has two distinct back-to-back

--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -44,11 +44,12 @@ Roles.new.pagerduty_roles.each do |role_id, role_config|
   end
 
   schedule_id = role_config[:pagerduty][:schedule_id]
-  assigned_shifts_this_schedule = pd.schedule(schedule_id, rota[:dates].first, rota[:dates].last)
+  assigned_shifts_this_schedule = pd.schedule(schedule_id, rota[:dates].first, (Time.zone.parse(rota[:dates].last) + 9.5.hours).iso8601)
 
   shifts_to_overwrite = shifts_to_assign.flatten.reject do |shift_to_assign|
     currently_assigned = assigned_shifts_this_schedule.find do |existing_shift|
-      existing_shift["start"] == shift_to_assign[:start_datetime]
+      existing_shift["start"] == shift_to_assign[:start_datetime] &&
+        existing_shift["end"] == shift_to_assign[:end_datetime]
     end
     currently_assigned && currently_assigned["user"]["summary"] == shift_to_assign[:person].name # person already assigned to this slot
   end

--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -63,7 +63,7 @@ Roles.new.pagerduty_roles.each do |role_id, role_config|
       # so we're getting this message. Would be great to fix this in future.
       puts "Warning: failed to assign #{shift_to_assign[:person].name} to the #{role_id} role from #{shift_to_assign[:start_datetime]} to #{shift_to_assign[:end_datetime]}. You'll need to apply this manually in the PagerDuty UI."
       next
-    elsif pagerduty_shifts_to_override.count > 1
+    elsif pagerduty_shifts_to_override.count.positive?
       puts "Overriding #{pagerduty_shifts_to_override.count} PagerDuty shifts for this shift."
     end
 

--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -44,7 +44,7 @@ Roles.new.pagerduty_roles.each do |role_id, role_config|
   end
 
   schedule_id = role_config[:pagerduty][:schedule_id]
-  assigned_shifts_this_schedule = pd.schedule(schedule_id, rota[:dates].first, (Time.zone.parse(rota[:dates].last) + 9.5.hours).iso8601)
+  assigned_shifts_this_schedule = pd.assigned_shifts_this_schedule(schedule_id, rota[:dates].first, rota[:dates].last)
 
   shifts_to_overwrite = shifts_to_assign.flatten.reject do |shift_to_assign|
     currently_assigned = assigned_shifts_this_schedule.find do |existing_shift|

--- a/lib/pagerduty_client.rb
+++ b/lib/pagerduty_client.rb
@@ -34,10 +34,11 @@ class PagerdutyClient
     users.flatten
   end
 
-  def schedule(schedule_id, from_date, to_date)
-    since_datetime = Time.zone.parse(from_date).iso8601
-    until_datetime = (Time.zone.parse(to_date) + 1.day).iso8601
+  def assigned_shifts_this_schedule(schedule_id, from_date, to_date)
+    schedule(schedule_id, Time.zone.parse(from_date).iso8601, (Time.zone.parse(to_date) + 1.day + 9.5.hours).iso8601)
+  end
 
+  def schedule(schedule_id, since_datetime, until_datetime)
     HTTParty.get(
       "https://api.pagerduty.com/schedules/#{schedule_id}?since=#{since_datetime}&until=#{until_datetime}",
       headers: {

--- a/lib/pagerduty_client.rb
+++ b/lib/pagerduty_client.rb
@@ -49,6 +49,16 @@ class PagerdutyClient
     )["schedule"]["final_schedule"]["rendered_schedule_entries"]
   end
 
+  def shifts_assigned_to_wrong_person(shifts_to_assign, assigned_shifts_this_schedule)
+    shifts_to_assign.flatten.reject do |shift_to_assign|
+      currently_assigned = assigned_shifts_this_schedule.find do |existing_shift|
+        existing_shift["start"] == shift_to_assign[:start_datetime] &&
+          existing_shift["end"] == shift_to_assign[:end_datetime]
+      end
+      currently_assigned && currently_assigned["user"]["summary"] == shift_to_assign[:person].name # person already assigned to this slot
+    end
+  end
+
   def create_override(schedule_id, pagerduty_user_id, start_datetime, end_datetime)
     override = {
       override: {

--- a/lib/pagerduty_client.rb
+++ b/lib/pagerduty_client.rb
@@ -59,6 +59,13 @@ class PagerdutyClient
     end
   end
 
+  def shifts_within_timespan(start_datetime, end_datetime, existing_pagerduty_shifts)
+    existing_pagerduty_shifts.select do |shift|
+      Time.zone.parse(shift["start"]) >= Time.zone.parse(start_datetime) &&
+        Time.zone.parse(shift["end"]) <= Time.zone.parse(end_datetime)
+    end
+  end
+
   def create_override(schedule_id, pagerduty_user_id, start_datetime, end_datetime)
     override = {
       override: {

--- a/spec/pagerduty_client_spec.rb
+++ b/spec/pagerduty_client_spec.rb
@@ -236,6 +236,37 @@ RSpec.describe PagerdutyClient do
     end
   end
 
+  describe "#shifts_within_timespan" do
+    it "returns the range of PagerDuty shifts covered by the start/end datetime" do
+      first_pd_shift = {
+        "start" => "2024-04-01T17:30:00+01:00",
+        "end" => "2024-04-02T09:30:00+01:00",
+      }
+      second_pd_shift = {
+        "start" => "2024-04-02T09:30:00+01:00",
+        "end" => "2024-04-02T17:30:00+01:00",
+      }
+      third_pd_shift = {
+        "start" => "2024-04-02T17:30:00+01:00",
+        "end" => "2024-04-03T09:30:00+01:00",
+      }
+      existing_pagerduty_shifts = [
+        first_pd_shift,
+        second_pd_shift,
+        third_pd_shift,
+      ]
+
+      start_datetime = "2024-04-01T17:30:00+01:00"
+      end_datetime = "2024-04-02T17:30:00+01:00"
+
+      pd = described_class.new(api_token: "foo")
+      expect(pd.shifts_within_timespan(start_datetime, end_datetime, existing_pagerduty_shifts)).to eq([
+        first_pd_shift,
+        second_pd_shift,
+      ])
+    end
+  end
+
   describe "#create_override" do
     it "sends an override request to PagerDuty" do
       schedule_id = "P999ABC"

--- a/spec/pagerduty_client_spec.rb
+++ b/spec/pagerduty_client_spec.rb
@@ -62,11 +62,27 @@ RSpec.describe PagerdutyClient do
     end
   end
 
+  describe "#assigned_shifts_this_schedule" do
+    it "figures out the timestamp for 9:30am the day after the last day of the rota, and passes that to #schedule" do
+      pd = described_class.new(api_token: "foo")
+      schedule_id = "schedule_id"
+      from_date = "01/01/1970"
+      to_date = "02/01/1970"
+      formatted_from_date = "1970-01-01T00:00:00+01:00"
+      manipulated_to_date = "1970-01-03T09:30:00+01:00"
+      return_value = "bar"
+
+      allow(pd).to receive(:schedule).with(schedule_id, formatted_from_date, manipulated_to_date).and_return(return_value)
+      expect(pd).to receive(:schedule).with(schedule_id, formatted_from_date, manipulated_to_date)
+      expect(pd.assigned_shifts_this_schedule(schedule_id, from_date, to_date)).to eq(return_value)
+    end
+  end
+
   describe "#schedule" do
     it "retrieves a specific schedule between two dates" do
       schedule_id = "P999ABC"
-      from_date = "01/04/2024"
-      to_date = "07/04/2024"
+      from_date = "2024-04-01T00:00:00+01:00"
+      to_date = "2024-04-08T00:00:00+01:00"
       rendered_schedule_entries = [
         {
           # on-call person 'carried over' from previous week


### PR DESCRIPTION
This PR:

- Fixes a bug whereby the on-call shift finished at midnight (instead of 09:30) on the last day of the quarter. See test screenshots below.
- Reduces the amount of "failed to assign" warnings requiring manual intervention.
- Moves much of the logic to `PagerdutyClient` and adds missing tests.

See commits for details.

| Before | After |
|-------|-------|
| <img alt="primary before" src="https://github.com/alphagov/govuk-rota-generator/assets/5111927/83043ece-09cd-448d-8c19-bf423cc8c651" width="400px"> | <img alt="primary after" src="https://github.com/alphagov/govuk-rota-generator/assets/5111927/39671c80-83ec-4b47-b711-a9d70e457069" width="400px"> |
| Primary | |
| <img alt="secondary before" src="https://github.com/alphagov/govuk-rota-generator/assets/5111927/efef4e11-be15-4b93-9899-136036970441" width="400px"> | <img alt="secondary after" src="https://github.com/alphagov/govuk-rota-generator/assets/5111927/af60099b-bd59-4722-9c0c-cb68a7f99a5f" width="400px"> |
| Secondary | |

Trello: https://trello.com/c/6osPAiWi/221-ensure-generated-rotas-finish-at-930am-rather-than-midnight