### PR TITLE
Pull engineer eligibility data from new spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run the `fetch_data` script, passing the URL of your responses spreadsheet as a 
 
 `ruby bin/fetch_data.rb https://docs.google.com/spreadsheets/d/abc123def456hij789/edit`
 
-This will generate a `data/rota_inputs.yml` file, combining your responses spreadsheet with the [Technical Support Google Sheet](https://docs.google.com/spreadsheets/d/1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU/edit#gid=1249170615).
+This will generate a `data/rota_inputs.yml` file, combining your responses spreadsheet with the 'Eligibility' sheet of the [List of GOV.UK Engineers](https://docs.google.com/spreadsheets/d/1uLW-T7VtGE4YKdCvzOvmq2KoeXgZMv-HOpt70HQnEcU/edit) (accessible by Senior Tech and 2nd Line Leads only).
 
 The generated file will look something like:
 

--- a/bin/fetch_data.rb
+++ b/bin/fetch_data.rb
@@ -3,7 +3,7 @@ require_relative "../lib/data_processor"
 require_relative "../lib/google_sheet"
 
 AVAILABILITY_SHEET_ID = ARGV.first.match(/spreadsheets\/d\/([^\/]+)/)[1]
-TECHNICAL_SUPPORT_SHEET_ID = "1OTVm_k6MDdCFN1EFzrKXWu4iIPI7uR9mssI8AMwn7lU".freeze
+ELIGIBILITY_SHEET_ID = "1uLW-T7VtGE4YKdCvzOvmq2KoeXgZMv-HOpt70HQnEcU".freeze
 RESPONSES_CSV = "#{File.dirname(__FILE__)}/../data/responses.csv".freeze
 PEOPLE_CSV = "#{File.dirname(__FILE__)}/../data/people.csv".freeze
 ROTA_INPUT_FILE = "#{File.dirname(__FILE__)}/../data/rota_inputs.yml".freeze
@@ -12,8 +12,8 @@ puts "Fetching developer availability..."
 GoogleSheet.new.fetch(sheet_id: AVAILABILITY_SHEET_ID, filepath: RESPONSES_CSV)
 puts "...downloaded to #{RESPONSES_CSV}"
 
-puts "Fetching 'Technical support' sheet..."
-GoogleSheet.new.fetch(sheet_id: TECHNICAL_SUPPORT_SHEET_ID, range: "Technical support!A1:Z", filepath: PEOPLE_CSV)
+puts "Fetching 'Eligibility' sheet..."
+GoogleSheet.new.fetch(sheet_id: ELIGIBILITY_SHEET_ID, range: "Eligibility!A1:Z", filepath: PEOPLE_CSV)
 puts "...downloaded to #{PEOPLE_CSV}."
 
 puts "Merging the two datasets..."

--- a/lib/data_processor.rb
+++ b/lib/data_processor.rb
@@ -22,7 +22,9 @@ class DataProcessor
   def self.create_people_from_csv_data(people_data, responses_data)
     validate_responses(responses_data)
 
-    people_data.map do |person_data|
+    people = people_data.map do |person_data|
+      next unless person_data["Email"]
+
       email = person_data["Email"]
       response_data = responses_data.find { |response| email == response["Email address"] }
       week_commencing_fields = []
@@ -51,16 +53,18 @@ class DataProcessor
           forbidden_dates.empty? ? nil : forbidden_dates
         }.compact.flatten,
         can_do_roles: [
-          person_data["Eligible for in-hours primary?"] == "Yes" ? :inhours_primary : nil,
-          person_data["Can do in-hours secondary?"] == "Yes" ? :inhours_secondary : nil,
-          person_data["Can do in-hours secondary?"] == "Yes" ? :inhours_standby : nil,
-          person_data["Should be scheduled for on-call?"] == "Yes" && person_data["Eligible for on-call primary?"] == "Yes" ? :oncall_primary : nil,
-          person_data["Should be scheduled for on-call?"] == "Yes" && person_data["Eligible for on-call secondary?"] == "Yes" ? :oncall_secondary : nil,
+          person_data["Eligible for in-hours Primary?"] == "Yes" ? :inhours_primary : nil,
+          person_data["Eligible for in-hours Secondary?"] == "Yes" ? :inhours_secondary : nil,
+          person_data["Eligible for in-hours Secondary?"] == "Yes" ? :inhours_standby : nil,
+          person_data["Eligible for on-call Primary?"] == "Yes" ? :oncall_primary : nil,
+          person_data["Eligible for on-call Secondary?"] == "Yes" ? :oncall_secondary : nil,
         ].compact,
       }
 
       Person.new(**person_args)
     end
+
+    people.compact
   end
 
   def self.non_working_days(comma_separated_days)

--- a/spec/data_processor_spec.rb
+++ b/spec/data_processor_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe DataProcessor do
   describe ".create_people_from_csv_data" do
     it "combines two CSV parsed inputs into one array of Person" do
       people_data = CSV.parse(<<~CSV, headers: true)
-        Email,Eligible for in-hours primary?,Can do in-hours secondary?,Eligible for on-call primary?,Eligible for on-call secondary?,Should be scheduled for on-call?
-        a@a.com,Yes,Yes,Yes,Yes,Yes
+        Email,Eligible for in-hours Primary?,Eligible for in-hours Secondary?,Eligible for on-call Primary?,Eligible for on-call Secondary?
+        a@a.com,Yes,Yes,Yes,Yes
       CSV
       responses_data = CSV.parse(<<~CSV, headers: true)
         Timestamp,Email address,Have you been given an exemption from on call?,Do you have any non working days? [Non working day(s)],What team/area are you in (or will be in when this rota starts)?,"If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours",Week commencing 01/04/2024,Week commencing 08/04/2024,Need to elaborate on any of the above?
@@ -47,8 +47,8 @@ RSpec.describe DataProcessor do
 
     it "assumes availability if the person hasn't provided availability responses" do
       people_data = CSV.parse(<<~CSV, headers: true)
-        Email,Eligible for in-hours primary?,Can do in-hours secondary?,Eligible for on-call primary?,Eligible for on-call secondary?,Should be scheduled for on-call?
-        a@a.com,Yes,Yes,Yes,Yes,Yes
+        Email,Eligible for in-hours Primary?,Eligible for in-hours Secondary?,Eligible for on-call Primary?,Eligible for on-call Secondary?
+        a@a.com,Yes,Yes,Yes,Yes
       CSV
       responses_data = CSV.parse(<<~CSV, headers: true)
         Timestamp,Email address,Have you been given an exemption from on call?,Do you have any non working days? [Non working day(s)],What team/area are you in (or will be in when this rota starts)?,"If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours",Week commencing 01/04/2024,Week commencing 08/04/2024,Need to elaborate on any of the above?
@@ -70,6 +70,19 @@ RSpec.describe DataProcessor do
       })
 
       described_class.create_people_from_csv_data(people_data, responses_data)
+    end
+
+    it "skips over any entries that are incomplete" do
+      people_data = CSV.parse(<<~CSV, headers: true)
+        Eligible for in-hours Primary?,Eligible for in-hours Secondary?,Eligible for on-call Primary?,Eligible for on-call Secondary?,Email,Some other field,Some other field again
+        Yes,Yes,Yes,Yes,a@a.com,foo,foo
+        No,No,No,No
+      CSV
+      responses_data = CSV.parse(<<~CSV, headers: true)
+        Timestamp,Email address,Have you been given an exemption from on call?,Do you have any non working days? [Non working day(s)],What team/area are you in (or will be in when this rota starts)?,"If you work different hours to the 9.30am-5.30pm 2nd line shifts, please state your hours",Week commencing 01/04/2024,Week commencing 08/04/2024,Need to elaborate on any of the above?
+      CSV
+
+      expect { described_class.create_people_from_csv_data(people_data, responses_data) }.not_to raise_exception
     end
   end
 

--- a/spec/fixtures/data_processor/combine_csvs/people.csv
+++ b/spec/fixtures/data_processor/combine_csvs/people.csv
@@ -1,2 +1,2 @@
-Email,Role,Team,Contractor Agency,Contractor?,Role allows doing in-hours?,Can do in-hours secondary?,Eligible for in-hours primary?,Role allows doing on-call?,Eligible for on-call primary?,Eligible for on-call secondary?,Exempt from on-call duties?,Should be scheduled for on-call?
-joe.bloggs@digital.cabinet-office.gov.uk,Developer,Platform,N/A,No,No,Yes,Yes,Yes,Yes,Yes,No,Yes
+Email,Eligible for in-hours Primary?,Eligible for in-hours Secondary?,Eligible for on-call Primary?,Eligible for on-call Secondary?
+joe.bloggs@digital.cabinet-office.gov.uk,Yes,Yes,Yes,Yes


### PR DESCRIPTION
Engineer eligibility for Primary/Secondary in-hours/on-call has been moved from the old (visible to all) Technical Support rota spreadsheet, and into a new 'list of GOV.UK engineers' sheet that is accessible to 2nd Line Leads and Senior Tech only. This is because we want to do a better job at tracking things like opt-out statuses, which are somewhat sensitive.

Trello: https://trello.com/c/QWOQKxVX/224-remove-logic-from-technical-support-sheet