### PR TITLE
Output fairness calculator to spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ Note that you can tweak the weighting of each 'role' (e.g. `oncall_primary`) by 
 
 ### Check the fairness of the rota
 
-Run `ruby bin/calculate_fairness.rb https://docs.google.com/spreadsheets/d/abc123def456hij789/edit`.
+This summarises the fairness of the rota. Before running the script, you'll need to add two new worksheets to the spreadsheet:
 
-This summarises the fairness of the rota. It looks for a "Manually tweaked rota" worksheet, so you'll first need to copy the "Auto-generated draft rota" into a new "Manually tweaked rota" worksheet in the same spreadsheet, and copy over the data. This allows you to freely tweak the output of the rota, without worrying about losing all of your changes next time you run the rota generator.
+1. "Manually tweaked rota" - you should copy over the "Auto-generated draft rota" into this. You're then free to tweak the output of the rota here, without worrying about losing all your changes next time you run the rota generator.
+2. "Fairness calculator" - blank worksheet, which will be populated by running the command below.
+
+Run `ruby bin/calculate_fairness.rb https://docs.google.com/spreadsheets/d/abc123def456hij789/edit`.
 
 ### Synchronise the rota with PagerDuty
 

--- a/bin/calculate_fairness.rb
+++ b/bin/calculate_fairness.rb
@@ -17,8 +17,29 @@ puts "Converting to YML..."
 DataProcessor.parse_csv(rota_csv: TMP_ROTA_CSV, roles_config:, rota_yml_output: TMP_ROTA_YML)
 puts "...saved to #{TMP_ROTA_YML}."
 
-puts "Fairness calculator"
-puts RotaPresenter.new(
+puts "Calculating fairness..."
+summary = RotaPresenter.new(
   people: YAML.load_file(TMP_ROTA_YML, symbolize_names: true)[:people].map { |person_data| Person.new(**person_data) },
   dates: [],
 ).fairness_summary(roles_config:)
+
+preamble = <<~PREAMBLE
+  The following people have been assigned shifts according to their eligibility and availability
+  (we have assumed 100% availability if they have not filled in the availability survey).
+  We've attempted to assess the fairness of the assigned shifts in the summary below.
+  When finding cover or arranging swaps, we should try to avoid burdening the folks higher up the list, instead
+  drawing from folks near the bottom of the list, but be careful to assign only shifts they're actually
+  eligible for - this is defined in:
+  https://docs.google.com/spreadsheets/d/1uLW-T7VtGE4YKdCvzOvmq2KoeXgZMv-HOpt70HQnEcU/edit?gid=1844919656.
+
+PREAMBLE
+
+puts "Writing fairness calculator results to Google Sheets"
+GoogleSheet.new(scope: :write).write(
+  sheet_id: ROTA_SHEET_ID,
+  range: "Fairness calculator!A1:Z1000",
+  csv: (preamble + summary).split("\n").map { |str| "\"#{str}\"" }.join("\n"),
+)
+puts "Writing fairness calculator results below:"
+puts ""
+puts summary


### PR DESCRIPTION
This makes it easier for the 2nd Line DM/PM/TL to easily retrieve these figures, which is useful for making manual edits to the rota.

Trello: https://trello.com/c/tTvui1p9/231-output-fairness-calculator-results-to-the-spreadsheet