### PR TITLE
Remove inhours_standby role from default rota generator

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -14,11 +14,6 @@ inhours_secondary:
   pagerduty:
     schedule_name: GOV.UK Secondary (2nd Call)
     schedule_id: P752O37
-inhours_standby:
-  value: 0.9
-  weekdays: true
-  weeknights: false
-  weekends: false
 oncall_primary:
   value: 1
   weekdays: false

--- a/lib/data_processor.rb
+++ b/lib/data_processor.rb
@@ -55,7 +55,6 @@ class DataProcessor
         can_do_roles: [
           person_data["Eligible for in-hours Primary?"] == "Yes" ? :inhours_primary : nil,
           person_data["Eligible for in-hours Secondary?"] == "Yes" ? :inhours_secondary : nil,
-          person_data["Eligible for in-hours Secondary?"] == "Yes" ? :inhours_standby : nil,
           person_data["Eligible for on-call Primary?"] == "Yes" ? :oncall_primary : nil,
           person_data["Eligible for on-call Secondary?"] == "Yes" ? :oncall_secondary : nil,
         ].compact,

--- a/spec/data_processor_spec.rb
+++ b/spec/data_processor_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe DataProcessor do
         can_do_roles: %i[
           inhours_primary
           inhours_secondary
-          inhours_standby
           oncall_primary
           oncall_secondary
         ],
@@ -63,7 +62,6 @@ RSpec.describe DataProcessor do
         can_do_roles: %i[
           inhours_primary
           inhours_secondary
-          inhours_standby
           oncall_primary
           oncall_secondary
         ],

--- a/spec/fixtures/data_processor/combine_csvs/rota_inputs.yml
+++ b/spec/fixtures/data_processor/combine_csvs/rota_inputs.yml
@@ -99,7 +99,6 @@ people:
   can_do_roles:
   - :inhours_primary
   - :inhours_secondary
-  - :inhours_standby
   - :oncall_primary
   - :oncall_secondary
   forbidden_in_hours_days:

--- a/spec/person_spec.rb
+++ b/spec/person_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Person do
       can_do_roles: %i[
         inhours_primary
         inhours_secondary
-        inhours_standby
         oncall_primary
       ],
       forbidden_in_hours_days: [
@@ -73,7 +72,6 @@ RSpec.describe Person do
   describe "#can_do_role?" do
     it "returns `true` for roles that the person can do" do
       expect(person.can_do_role?(:inhours_primary)).to be(true)
-      expect(person.can_do_role?(:inhours_standby)).to be(true)
     end
 
     it "returns `false` for roles that the person cannot do" do
@@ -86,7 +84,6 @@ RSpec.describe Person do
       expect(person.availability(date: "08/04/2024")).to eq(%i[
         inhours_primary
         inhours_secondary
-        inhours_standby
         oncall_primary
       ])
     end


### PR DESCRIPTION
As of Q3, we will no longer allocate a standby role, reflecting the move from "Technical 2nd Line" to "in-hours on-call". The existing out-of-hours on-call doesn't have a standby role either, so this makes that consistent, and should also lead to a fairer distribution of shifts.