### PR TITLE
Run PagerDuty sync script on cronjob

### DIFF
--- a/.github/workflows/sync_pagerduty.yml
+++ b/.github/workflows/sync_pagerduty.yml
@@ -1,0 +1,30 @@
+name: "Synchronise rota with PagerDuty"
+
+on:
+  # TODO: uncomment the below once we've tested the script is working
+  # schedule:
+  #   - cron:  '0 8 * * *'
+  workflow_dispatch: {}
+  # TODO: remove the below - we only want to run the workflow on push while we're testing the logic
+  push:
+    branches: [sync-pagerduty-on-cron]
+
+jobs:
+  sync-pagerduty:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Synchronise PagerDuty
+        run: bundle exec rake sync_pagerduty[true]
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY : ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          PAGER_DUTY_API_KEY: ${{ secrets.PAGER_DUTY_API_KEY }}
+          ROTA_SHEET_URL: ${{ secrets.ROTA_SHEET_URL }}
+          ROTA_TAB_NAME: ${{ secrets.ROTA_TAB_NAME }}

--- a/.github/workflows/sync_pagerduty.yml
+++ b/.github/workflows/sync_pagerduty.yml
@@ -5,9 +5,6 @@ on:
     # synchronise PagerDuty every hour (8pm-6pm) during the working week
     - cron:  '0 8-18 * * 1-5'
   workflow_dispatch: {}
-  # TODO: remove the below - we only want to run the workflow on push while we're testing the logic
-  push:
-    branches: [sync-pagerduty-on-cron]
 
 jobs:
   sync-pagerduty:

--- a/.github/workflows/sync_pagerduty.yml
+++ b/.github/workflows/sync_pagerduty.yml
@@ -28,3 +28,33 @@ jobs:
           PAGER_DUTY_API_KEY: ${{ secrets.PAGER_DUTY_API_KEY }}
           ROTA_SHEET_URL: ${{ secrets.ROTA_SHEET_URL }}
           ROTA_TAB_NAME: ${{ secrets.ROTA_TAB_NAME }}
+
+      - name: Notify failure
+        uses: slackapi/slack-github-action@v1
+        if: ${{ failure() }}
+        with:
+          payload: |
+            {
+              "text": "The <https://github.com/alphagov/govuk-rota-generator/blob/main/.github/workflows/sync_pagerduty.yml|PagerDuty sync script> failed.",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The <https://github.com/alphagov/govuk-rota-generator/blob/main/.github/workflows/sync_pagerduty.yml|PagerDuty sync script> failed."
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Check the build logs for details"
+                    },
+                    "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                    "action_id": "button-view-workflow"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/sync_pagerduty.yml
+++ b/.github/workflows/sync_pagerduty.yml
@@ -1,9 +1,9 @@
 name: "Synchronise rota with PagerDuty"
 
 on:
-  # TODO: uncomment the below once we've tested the script is working
-  # schedule:
-  #   - cron:  '0 8 * * *'
+  schedule:
+    # synchronise PagerDuty every hour (8pm-6pm) during the working week
+    - cron:  '0 8-18 * * 1-5'
   workflow_dispatch: {}
   # TODO: remove the below - we only want to run the workflow on push while we're testing the logic
   push:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "activesupport"
 gem "google-apis-sheets_v4"
 gem "googleauth"
 gem "httparty"
+gem "rake"
 
 group :test do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     racc (1.8.0)
     rack (3.1.6)
     rainbow (3.1.1)
+    rake (13.2.1)
     regexp_parser (2.9.2)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -167,6 +168,7 @@ DEPENDENCIES
   google-apis-sheets_v4
   googleauth
   httparty
+  rake
   rspec
   rubocop-govuk
   simplecov

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Run `ruby bin/calculate_fairness.rb https://docs.google.com/spreadsheets/d/abc12
 
 govuk-rota-generator automatically synchronises the Google Sheet rota with PagerDuty [on a regular basis](.github/workflows/sync_pagerduty.yml).
 
-The three ENV vars described in [Run the synchroniser script](#run-the-synchroniser-script), as well as the `GOOGLE_SERVICE_ACCOUNT_KEY` key from the [setup](#setup) phase, are stored as secrets on this repository.
+The three ENV vars described in [Run the synchroniser script](#run-the-synchroniser-script), as well as the `GOOGLE_SERVICE_ACCOUNT_KEY` key from the [setup](#setup) phase, are stored as secrets on this repository. A failure notification is sent to Slack if the sync fails - the destination is determined by the `SLACK_WEBHOOK_URL` secret (reused from govuk-saas-config).
 
 Every quarter, a developer will need to swap out the `ROTA_TAB_NAME` to reflect the name of the next rota that needs synchronising.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Run `ruby bin/calculate_fairness.rb https://docs.google.com/spreadsheets/d/abc12
 
 ### Synchronise the rota with PagerDuty
 
+govuk-rota-generator automatically synchronises the Google Sheet rota with PagerDuty [on a regular basis](.github/workflows/sync_pagerduty.yml).
+
+The three ENV vars described in [Run the synchroniser script](#run-the-synchroniser-script), as well as the `GOOGLE_SERVICE_ACCOUNT_KEY` key from the [setup](#setup) phase, are stored as secrets on this repository.
+
+Every quarter, a developer will need to swap out the `ROTA_TAB_NAME` to reflect the name of the next rota that needs synchronising.
+
+Below are the instructions for running the synchroniser manually.
+
 #### Export an API key
 
 You'll need a PagerDuty API key associated with PagerDuty account that has "Global Admin" access (which can be [configured in govuk-user-reviewer](https://github.com/alphagov/govuk-user-reviewer/blob/89102b7778cdf391e4aa6f3e830615093101cc39/config/govuk_tech.yml#L258-L260)):

--- a/README.md
+++ b/README.md
@@ -94,23 +94,22 @@ You'll need a PagerDuty API key associated with PagerDuty account that has "Glob
 1. Click on "User Settings"
 1. Click "Create API User Token"
 
-Export this token as an ENV variable:
-
-```sh
-export PAGER_DUTY_API_KEY=$(more ~/pagerduty_token.txt)
-```
+Store this token somewhere safe, e.g. `~/pagerduty_token.txt`.
 
 #### Run the synchroniser script
 
 You can now synchronise a rota with PagerDuty using:
 
 ```sh
-ruby bin/sync_pagerduty.rb
+$ export ROTA_SHEET_URL="https://docs.google.com/spreadsheets/d/<sheet id>/edit"
+$ export ROTA_TAB_NAME="Q3 24/25 Rota"                                                                            
+$ export PAGER_DUTY_API_KEY=$(more ~/pagerduty_token.txt)
+$ bundle exec rake sync_pagerduty[false]
 ```
 
 This will:
 
-1. Use the rota in `data/tmp_rota.yml` (created automatically by the "calculate fairness" script)
+1. Fetch the rota corresponding to `ROTA_SHEET_URL` and `ROTA_TAB_NAME`
 1. Map the roles in that rota to the roles in `config/roles.yml`, where it finds the corresponding PagerDuty schedule IDs
 1. Fetch the list of PagerDuty users and match these up with the users in your rota, warning on any names that are missing from PagerDuty (and skipping over those shifts)±
 1. Find conflicts between the PagerDuty schedule and the local rota, and apply overrides to fix them
@@ -119,8 +118,8 @@ This will:
 
 By default, the script will ask you to approve each override: `y` to override, `n` to skip, and `exit` to close the script altogether. This means you can do a 'dry run' of the synchroniser by choosing `n` each time.
 
-If you wish to approve all of the overrides at once, you can pass the `--bulk` option:
+If you wish to approve all of the overrides at once, you can pass `true` to the rake task:
 
 ```sh
-ruby bin/sync_pagerduty.rb --bulk
+bundle exec rake sync_pagerduty[true]
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require_relative "bin/sync_pagerduty.rb"
+
+desc "Send publishable item links of a specific type to Publishing API (ie, 'CaseStudy')."
+task :sync_pagerduty, [:bulk_apply_overrides] do |_, args|
+  SyncPagerduty.new.execute(bulk_apply_overrides: args[:bulk_apply_overrides] == "true")
+end

--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -1,115 +1,136 @@
+require "yaml"
+require_relative "../lib/data_processor"
+require_relative "../lib/google_sheet"
 require_relative "../lib/pagerduty_client"
 require_relative "../lib/person"
 require_relative "../lib/roles"
 
-rota = YAML.load_file("#{File.dirname(__FILE__)}/../data/tmp_rota.yml", symbolize_names: true)
-overridden_names = YAML.load_file("#{File.dirname(__FILE__)}/../config/pagerduty_config_overrides.yml", symbolize_names: true)
-pd = PagerdutyClient.new(api_token: ENV.fetch("PAGER_DUTY_API_KEY"))
+ROTA_SHEET_ID = ENV.fetch("ROTA_SHEET_URL").match(/spreadsheets\/d\/([^\/]+)/)[1]
+ROTA_TAB_NAME = ENV.fetch("ROTA_TAB_NAME")
+PAGER_DUTY_API_KEY = ENV.fetch("PAGER_DUTY_API_KEY")
+TMP_ROTA_CSV = "#{File.dirname(__FILE__)}/../data/tmp_rota.csv".freeze
+TMP_ROTA_YML = "#{File.dirname(__FILE__)}/../data/tmp_rota.yml".freeze
 
-bulk_yes = false
-if ARGV.first == "--bulk"
-  puts "--bulk parameter supplied. Bulk-applying overrides..."
-  bulk_yes = true
-end
+class SyncPagerduty
+  def execute(bulk_apply_overrides: false)
+    roles_config = YAML.load_file("#{File.dirname(__FILE__)}/../config/roles.yml", symbolize_names: true)
 
-puts "Fetching list of users from PagerDuty..."
-users = pd.users
-puts "...fetched."
+    puts "Fetching rota..."
+    GoogleSheet.new.fetch(sheet_id: ROTA_SHEET_ID, range: "#{ROTA_TAB_NAME}!A1:Z", filepath: TMP_ROTA_CSV)
+    puts "...downloaded to #{TMP_ROTA_CSV}."
 
-people = rota[:people].map do |person_data|
-  person = Person.new(
-    email: person_data[:email],
-    team: "Unknown",
-    can_do_roles: [], # unknown - but doesn't matter
-    assigned_shifts: person_data[:assigned_shifts],
-  )
-  if (overridden_name = overridden_names[:names].find { |name| name[:derived_from_email] == person.name })
-    person.name = overridden_name[:pagerduty]
-  end
+    puts "Converting to YML..."
+    DataProcessor.parse_csv(rota_csv: TMP_ROTA_CSV, roles_config:, rota_yml_output: TMP_ROTA_YML)
+    puts "...saved to #{TMP_ROTA_YML}."
 
-  if (pagerduty_user = users.find { |user| user["name"] == person.name })
-    person.pagerduty_user_id = pagerduty_user["id"]
-    person
-  else
-    puts "No PagerDuty user found for '#{person.name}' (do they have Production Admin access?). Skipping overriding their shifts..."
-    nil
-  end
-end
-people.compact!
+    rota = YAML.load_file(TMP_ROTA_YML, symbolize_names: true)
+    overridden_names = YAML.load_file("#{File.dirname(__FILE__)}/../config/pagerduty_config_overrides.yml", symbolize_names: true)
+    pd = PagerdutyClient.new(api_token: PAGER_DUTY_API_KEY)
 
-Roles.new.pagerduty_roles.each do |role_id, role_config|
-  puts "Processing #{role_id} shifts..."
-
-  schedule_id = role_config[:pagerduty][:schedule_id]
-  shifts_to_assign = people.map do |person|
-    person.formatted_shifts(role_id).map { |shift| { person:, **shift } }
-  end
-  assigned_shifts_this_schedule = pd.assigned_shifts_this_schedule(schedule_id, rota[:dates].first, rota[:dates].last)
-  shifts_to_overwrite = pd.shifts_assigned_to_wrong_person(shifts_to_assign, assigned_shifts_this_schedule)
-
-  puts "Overriding #{shifts_to_overwrite.count} individual shifts in PagerDuty..."
-  shifts_to_overwrite.each do |shift_to_assign|
-    pagerduty_shifts_to_override = pd.shifts_within_timespan(
-      shift_to_assign[:start_datetime],
-      shift_to_assign[:end_datetime],
-      assigned_shifts_this_schedule,
-    )
-
-    if pagerduty_shifts_to_override.empty?
-      # TODO: this message can happen when someone has two distinct back-to-back
-      # shifts, e.g. someone covering bank holiday may have inhours_primary 9:30-17:30
-      # followed by oncall_primary 17:30-9:30. PagerDuty API returns this as one
-      # 9:30-9:30 shift, which doesn't match our internal representation of two shifts,
-      # so we're getting this message. Would be great to fix this in future.
-      puts "Warning: failed to assign #{shift_to_assign[:person].name} to the #{role_id} role from #{shift_to_assign[:start_datetime]} to #{shift_to_assign[:end_datetime]}. You'll need to apply this manually in the PagerDuty UI."
-      next
-    elsif pagerduty_shifts_to_override.count.positive?
-      puts "Overriding #{pagerduty_shifts_to_override.count} PagerDuty shifts for this shift."
+    if bulk_apply_overrides
+      puts "Bulk-applying overrides..."
     end
 
-    pagerduty_shifts_to_override.each do |existing|
-      # Sometimes, for whatever reason, part of a long shift has already been assigned to the right user.
-      # e.g. a 17:30 Friday -> 09:30 Monday, where perhaps the correct person is assigned apart from for
-      # the 09:30 Sunday -> 09:30 Monday slot. In this case, the start/end times for the person's shift
-      # don't match and so all of the composite parts of the shift are included in
-      # `pagerduty_shifts_to_override`. We can safely skip over the correctly assigned shifts and just
-      # let the one 'bad' shift get prompted and overwritten. On subsequent runs of the script, the
-      # entire shift would no longer be included in `pagerduty_shifts_to_override`, as the start/end
-      # timestamps would now match.
-      next if shift_to_assign[:person].name == existing["user"]["summary"]
+    puts "Fetching list of users from PagerDuty..."
+    users = pd.users
+    puts "...fetched."
 
-      puts "Set #{shift_to_assign[:person].name} as the #{role_id} from #{shift_to_assign[:start_datetime]}-#{shift_to_assign[:end_datetime]} (replacing #{existing['user']['summary']})? y/n/exit"
+    people = rota[:people].map do |person_data|
+      person = Person.new(
+        email: person_data[:email],
+        team: "Unknown",
+        can_do_roles: [], # unknown - but doesn't matter
+        assigned_shifts: person_data[:assigned_shifts],
+      )
+      if (overridden_name = overridden_names[:names].find { |name| name[:derived_from_email] == person.name })
+        person.name = overridden_name[:pagerduty]
+      end
 
-      valid_action = false
-      action = false
-      if bulk_yes
-        action = "y"
+      if (pagerduty_user = users.find { |user| user["name"] == person.name })
+        person.pagerduty_user_id = pagerduty_user["id"]
+        person
       else
-        until valid_action
-          action = gets.chomp
-          valid_action = %w[y n exit].include?(action)
-          puts "Option #{action.inspect} not recognised" unless valid_action
-        end
-      end
-
-      case action
-      when "y"
-        puts "Overwriting... #{shift_to_assign[:person].pagerduty_user_id} to #{existing['start']} to #{existing['end']}"
-        response = pd.create_override(schedule_id, shift_to_assign[:person].pagerduty_user_id, existing["start"], existing["end"])
-
-        if response.code == 400
-          puts "...error applying override."
-          puts response.body
-        else
-          puts "...overwrite applied!"
-        end
-      when "n"
-        puts "Skipping."
-        next
-      when "exit"
-        exit
+        puts "No PagerDuty user found for '#{person.name}' (do they have Production Admin access?). Skipping overriding their shifts..."
+        nil
       end
     end
+    people.compact!
+
+    Roles.new.pagerduty_roles.each do |role_id, role_config|
+      puts "Processing #{role_id} shifts..."
+
+      schedule_id = role_config[:pagerduty][:schedule_id]
+      shifts_to_assign = people.map do |person|
+        person.formatted_shifts(role_id).map { |shift| { person:, **shift } }
+      end
+      assigned_shifts_this_schedule = pd.assigned_shifts_this_schedule(schedule_id, rota[:dates].first, rota[:dates].last)
+      shifts_to_overwrite = pd.shifts_assigned_to_wrong_person(shifts_to_assign, assigned_shifts_this_schedule)
+
+      puts "Overriding #{shifts_to_overwrite.count} individual shifts in PagerDuty..."
+      shifts_to_overwrite.each do |shift_to_assign|
+        pagerduty_shifts_to_override = pd.shifts_within_timespan(
+          shift_to_assign[:start_datetime],
+          shift_to_assign[:end_datetime],
+          assigned_shifts_this_schedule,
+        )
+
+        if pagerduty_shifts_to_override.empty?
+          # TODO: this message can happen when someone has two distinct back-to-back
+          # shifts, e.g. someone covering bank holiday may have inhours_primary 9:30-17:30
+          # followed by oncall_primary 17:30-9:30. PagerDuty API returns this as one
+          # 9:30-9:30 shift, which doesn't match our internal representation of two shifts,
+          # so we're getting this message. Would be great to fix this in future.
+          puts "Warning: failed to assign #{shift_to_assign[:person].name} to the #{role_id} role from #{shift_to_assign[:start_datetime]} to #{shift_to_assign[:end_datetime]}. You'll need to apply this manually in the PagerDuty UI."
+          next
+        elsif pagerduty_shifts_to_override.count.positive?
+          puts "Overriding #{pagerduty_shifts_to_override.count} PagerDuty shifts for this shift."
+        end
+
+        pagerduty_shifts_to_override.each do |existing|
+          # Sometimes, for whatever reason, part of a long shift has already been assigned to the right user.
+          # e.g. a 17:30 Friday -> 09:30 Monday, where perhaps the correct person is assigned apart from for
+          # the 09:30 Sunday -> 09:30 Monday slot. In this case, the start/end times for the person's shift
+          # don't match and so all of the composite parts of the shift are included in
+          # `pagerduty_shifts_to_override`. We can safely skip over the correctly assigned shifts and just
+          # let the one 'bad' shift get prompted and overwritten. On subsequent runs of the script, the
+          # entire shift would no longer be included in `pagerduty_shifts_to_override`, as the start/end
+          # timestamps would now match.
+          next if shift_to_assign[:person].name == existing["user"]["summary"]
+
+          puts "Set #{shift_to_assign[:person].name} as the #{role_id} from #{shift_to_assign[:start_datetime]}-#{shift_to_assign[:end_datetime]} (replacing #{existing['user']['summary']})? y/n/exit"
+
+          valid_action = false
+          action = false
+          if bulk_apply_overrides
+            action = "y"
+          else
+            until valid_action
+              action = gets.chomp
+              valid_action = %w[y n exit].include?(action)
+              puts "Option #{action.inspect} not recognised" unless valid_action
+            end
+          end
+
+          case action
+          when "y"
+            puts "Overwriting... #{shift_to_assign[:person].pagerduty_user_id} to #{existing['start']} to #{existing['end']}"
+            response = pd.create_override(schedule_id, shift_to_assign[:person].pagerduty_user_id, existing["start"], existing["end"])
+
+            if response.code == 400
+              puts "...error applying override."
+              puts response.body
+            else
+              puts "...overwrite applied!"
+            end
+          when "n"
+            puts "Skipping."
+            next
+          when "exit"
+            exit
+          end
+        end
+      end
+      puts "Finished overriding #{role_id} shifts."
+    end
   end
-  puts "Finished overriding #{role_id} shifts."
 end

--- a/config/pagerduty_config_overrides.yml
+++ b/config/pagerduty_config_overrides.yml
@@ -3,5 +3,9 @@ names:
     pagerduty: Ana Castillo Botto
   - derived_from_email: George Schena1
     pagerduty: George Schena
+  - derived_from_email: Mark Taylor1
+    pagerduty: Mark Taylor
   - derived_from_email: Murilo Dalri
     pagerduty: Murilo Dal Ri
+  - derived_from_email: Syed Ali1
+    pagerduty: Syed Ali

--- a/spec/google_sheet_spec.rb
+++ b/spec/google_sheet_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe GoogleSheet do
   before do
     mock_authorizer = double("Google Authorizer", fetch_access_token!: true) # rubocop:disable RSpec/VerifiedDoubles
     allow(Google::Auth::ServiceAccountCredentials).to receive(:make_creds).and_return(mock_authorizer)
-    allow(File).to receive(:open).with("./google_service_account_key.json").and_return("{}")
   end
 
   let(:sheet_id) { "1sK8ktAnffewnfiewnfoewifnwoein" }
@@ -14,7 +13,30 @@ RSpec.describe GoogleSheet do
     mock_sheets_api
   end
 
+  def stub_google_service_account_key_file
+    allow(File).to receive(:file?).with("./google_service_account_key.json").and_return(true)
+    allow(File).to receive(:open).with("./google_service_account_key.json").and_return("{}")
+  end
+
+  describe "initialising class with google service account key" do
+    it "uses ENV var if that exists" do
+      stub_const("GoogleSheet::GOOGLE_SERVICE_ACCOUNT_KEY", "foo")
+      expect { described_class.new(sheets_api: mock_sheets_api) }.not_to raise_exception
+    end
+
+    it "uses file if no ENV var exists" do
+      stub_google_service_account_key_file
+      expect { described_class.new(sheets_api: mock_sheets_api) }.not_to raise_exception
+    end
+
+    it "errors if no ENV var and no file exist" do
+      expect { described_class.new(sheets_api: mock_sheets_api) }.to raise_exception(GoogleSheetException)
+    end
+  end
+
   describe "#fetch" do
+    before { stub_google_service_account_key_file }
+
     it "returns data if sheet is found" do
       range = "SomeWorksheet!A1:Z"
       mock_response = instance_double(Google::Apis::SheetsV4::ValueRange, values: %w[foo])
@@ -56,6 +78,8 @@ RSpec.describe GoogleSheet do
   end
 
   describe "#write" do
+    before { stub_google_service_account_key_file }
+
     let(:range) { "SomeWorksheet!A1:Z" }
 
     it "clears the sheet before writing values" do


### PR DESCRIPTION
Best reviewed commit by commit.

The `Write PagerDuty sync cron job` commit should be viewed [with whitespace disabled](https://github.com/alphagov/govuk-rota-generator/pull/74/commits/49dead9d8a6d18aa35a00a33670bd4655b78620d?w=1), to minimise the diff, since there are few code changes apart from indentation.

Trello: https://trello.com/c/hGaawZt1/220-automate-pagerduty-on-a-cron