### PR TITLE
Avoid overriding shifts that have already ended

### DIFF
--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -71,6 +71,8 @@ class SyncPagerduty
 
       puts "Overriding #{shifts_to_overwrite.count} individual shifts in PagerDuty..."
       shifts_to_overwrite.each do |shift_to_assign|
+        next if pd.in_past?(shift_to_assign[:end_datetime])
+
         pagerduty_shifts_to_override = pd.shifts_within_timespan(
           shift_to_assign[:start_datetime],
           shift_to_assign[:end_datetime],

--- a/lib/pagerduty_client.rb
+++ b/lib/pagerduty_client.rb
@@ -59,6 +59,10 @@ class PagerdutyClient
     end
   end
 
+  def in_past?(datetime)
+    Time.zone.parse(datetime) <= Time.now
+  end
+
   def shifts_within_timespan(start_datetime, end_datetime, existing_pagerduty_shifts)
     existing_pagerduty_shifts.select do |shift|
       Time.zone.parse(shift["start"]) >= Time.zone.parse(start_datetime) &&

--- a/lib/pagerduty_client.rb
+++ b/lib/pagerduty_client.rb
@@ -60,7 +60,7 @@ class PagerdutyClient
   end
 
   def in_past?(datetime)
-    Time.zone.parse(datetime) <= Time.now
+    Time.zone.parse(datetime) <= Time.zone.now
   end
 
   def shifts_within_timespan(start_datetime, end_datetime, existing_pagerduty_shifts)

--- a/spec/pagerduty_client_spec.rb
+++ b/spec/pagerduty_client_spec.rb
@@ -238,6 +238,18 @@ RSpec.describe PagerdutyClient do
     end
   end
 
+  describe "#in_past?" do
+    let(:pd) { described_class.new(api_token: "foo") }
+
+    it "returns true if the datetime is in the past" do
+      expect(pd.in_past?("2019-01-01T09:30:00+01:00")).to be(true)
+    end
+
+    it "returns false if the datetime is in the future" do
+      expect(pd.in_past?("3000-01-01T09:30:00+01:00")).to be(false)
+    end
+  end
+
   describe "#shifts_within_timespan" do
     it "returns the range of PagerDuty shifts covered by the start/end datetime" do
       first_pd_shift = {


### PR DESCRIPTION
This prevents an [error](https://github.com/alphagov/govuk-rota-generator/actions/runs/11107817588/job/30859313842)
whereby if the wrong person is assigned in PagerDuty for a shift
that has already started, the sync script fails.

We started the quarter with the wrong person assigned to a
Secondary shift (as they didn't yet have a PagerDuty account).
This was corrected within a couple of hours, but PagerDuty doesn't
let us retrospectively override the part of the shift that was
assigned to the wrong person. So we're forced to add this logic to
skip over shifts that have happened already, so that we don't
attempt to override them.

This does mean unfortunately we'll have some slightly confusing
output for the entirety of the quarter (the `shifts_to_overwrite`
variable is counted irrespective of when the shifts started, so
it will always look like we're trying to override one shift even
though it then gets skipped on line 74):

```
Processing inhours_primary shifts...
Overriding 0 individual shifts in PagerDuty...
Finished overriding inhours_primary shifts.
Processing inhours_secondary shifts...
Overriding 1 individual shifts in PagerDuty...
Finished overriding inhours_secondary shifts.
Processing oncall_primary shifts...
Overriding 0 individual shifts in PagerDuty...
Finished overriding oncall_primary shifts.
Processing oncall_secondary shifts...
Overriding 1 individual shifts in PagerDuty...
Overriding 1 PagerDuty shifts for this shift.
Finished overriding oncall_secondary shifts.
```

Trello: https://trello.com/c/hGaawZt1/220-automate-pagerduty-synchronisation-on-a-regular-cronjob
