### PR TITLE
Reduce regularity of PagerDuty synchronisation to once daily

### DIFF
--- a/.github/workflows/sync_pagerduty.yml
+++ b/.github/workflows/sync_pagerduty.yml
@@ -2,8 +2,8 @@ name: "Synchronise rota with PagerDuty"
 
 on:
   schedule:
-    # synchronise PagerDuty every hour (8pm-6pm) during the working week
-    - cron:  '0 8-18 * * 1-5'
+    # synchronise PagerDuty every morning during the working week
+    - cron:  '0 8 * * 1-5'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
We have a situation where one of our in-hours Primary engineers will be covered by a different engineer *for an afternoon*. Currently, govuk-rota-generator does not work in more granular terms than full days. Therefore, if we manually apply an override for the afternoon, the Pagerduty sync script will overwrite that on its next hourly run.

Supporting an hourly granularity is possible in theory. It would require:

- Supporting a new formatting in the rota spreadsheet cell, e.g. `Developer A (Developer B on 11/10/2024 from 12:00-17:30)`.
- Optionally including a `time_range` key alongside the `date` and `role` keys [here](https://github.com/alphagov/govuk-rota-generator/blob/20a6560fb1de44e6349b7ccca22fe618336b9148/lib/person.rb#L56)
- Editing the `Roles.start_datetime`/`end_datetime` methods to return the supplied `time_range` values if supplied, falling back to the roles config if not supplied.
- Adding validation / protection / rules to ensure that the 'gaps' are automatically filled in. For example, an override of Developer B from 10:30-11:45 should result in shifts for Developer A from 09:30-10:30 and 11:45-17:30.

Whilst the first few points are fairly doable, the latter requires more work than we're able to dedicate to govuk-rota-generator at present. Thus we'll just reduce the regularity of the sync script, giving us a generous window in which to manually apply an afternoon override on the day that it is needed. The next sync script would run the morning after the overridden shift, and as of #75, the sync script shouldn't be looking at shifts in the past, so won't complain about it or attempt to override it.

Trello: https://trello.com/c/SDvJ4bBd/267-tweak-pagerduty-sync-script-to-work-in-terms-of-hours