### PR TITLE
Fix PagerDuty synchronisation output

### DIFF
--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -116,7 +116,7 @@ class SyncPagerduty
             action = "y"
           else
             until valid_action
-              action = gets.chomp
+              action = $stdin.gets.chomp
               valid_action = %w[y n exit].include?(action)
               puts "Option #{action.inspect} not recognised" unless valid_action
             end

--- a/bin/sync_pagerduty.rb
+++ b/bin/sync_pagerduty.rb
@@ -73,11 +73,12 @@ class SyncPagerduty
       end
       assigned_shifts_this_schedule = pd.assigned_shifts_this_schedule(schedule_id, rota[:dates].first, rota[:dates].last)
       shifts_to_overwrite = pd.shifts_assigned_to_wrong_person(shifts_to_assign, assigned_shifts_this_schedule)
+      shifts_to_overwrite = shifts_to_overwrite.reject do |shift|
+        pd.in_past?(shift[:end_datetime])
+      end
 
       puts "Overriding #{shifts_to_overwrite.count} shifts in PagerDuty..."
       shifts_to_overwrite.each do |shift_to_assign|
-        next if pd.in_past?(shift_to_assign[:end_datetime])
-
         existing_shifts = pd.find_corresponding_shifts(assigned_shifts_this_schedule, shift_to_assign)
         existing_users = existing_shifts.map { |shift| shift["user"]["summary"] }
 


### PR DESCRIPTION
The PagerDuty sync script was working fine, but the output would warn about any cases where two distinct shifts (e.g. 9:30-17:30, 17:30-9:30) run together with the same assignee. Because the start/end dates of a shift for a particular assignee would not match the YAML (it would show 9:30-9:30 in the example above) then we'd have a warning that the shift failed to assign, even though the correct assignee has been set for all time periods.

To fix up the reporting of this, we've changed the logic of _how_ we override shifts, now taking a new approach of "here PagerDuty: take these times and names and just do your thing" rather than a "excuse me PagerDuty, who do you have assigned to every 'time slot', so that I can cross reference and attempt to override only where we've fallen out of sync?". This fixes #98 - we should no longer need to manually step in to perform overrides for the more 'complicated' shifts.

Finally, this PR fixes up the rake task STDIN input, and also fixes up the "Overriding n shifts" message (which incorrectly included shifts 'in the past' that have no chance of being overridden).

Trello: https://trello.com/c/AF57Vglv/304-fix-pagerduty-synchronisation-logic